### PR TITLE
Update qsettings.cpp

### DIFF
--- a/src/core/io/qsettings.cpp
+++ b/src/core/io/qsettings.cpp
@@ -1441,7 +1441,7 @@ void QConfFileSettingsPrivate::syncConfFile(int confFileNo)
    */
    QFile file(confFile->name);
    bool createFile = !file.exists();
-   if (!readOnly && confFile->isWritable()) {
+   if ((!readOnly && confFile->isWritable()) || createFile) {
       file.open(QFile::ReadWrite);
    }
    if (!file.isOpen()) {


### PR DESCRIPTION
Fix. When QConfFileSettingsPrivate :: syncConfFile (int confFileNo) with instructions  tries to open the file in read-only and this does not exist, QFSFileEnginePrivate :: nativeOpen (QIODevice :: OpenMode openMode) (in qfsfileengine_unix.cpp) returned an error (errno = 2 file or directory that does not exist) because the file has not yet been created.