### PR TITLE
Work around a possible bug in MSVC.

### DIFF
--- a/src/core/kernel/csobject_macro.h
+++ b/src/core/kernel/csobject_macro.h
@@ -446,7 +446,7 @@ class cs_number<0>
 
 
 // ** signals
-#define CS_SIGNAL_1(access, ...) \
+#define CS_SIGNAL_INTERNAL_1(access, ...) \
    static constexpr const int CS_TOKENPASTE2(cs_counter_value, __LINE__) =  \
             decltype(cs_counter(cs_number<255>{}))::value; \
    static constexpr cs_number<CS_TOKENPASTE2(cs_counter_value, __LINE__) + 1>  \
@@ -461,13 +461,13 @@ class cs_number<0>
          \
          cs_regTrigger(cs_number<CS_TOKENPASTE2(cs_counter_value, __LINE__) + 1>{} ); \
       }  \
-   Q_DECL_EXPORT __VA_ARGS__ {
+   Q_DECL_EXPORT __VA_ARGS__
+
 // do not remove the "{", this is required for part two of the macro
+#define CS_SIGNAL_1(access, ...) CS_SIGNAL_INTERNAL_1(access, __VA_ARGS__) {
+#define CS_SIGNAL_DECLARE_1(access, ...) CS_SIGNAL_INTERNAL_1(access, __VA_ARGS__);
 
-
-#define CS_SIGNAL_2(signalName, ...) \
-      QMetaObject::activate(this, &cs_class::signalName, ##__VA_ARGS__); \
-   }  \
+#define CS_SIGNAL_INTERNAL_2(signalName) \
    static constexpr int CS_TOKENPASTE2(cs_counter_value, __LINE__) =  \
             decltype(cs_counter(cs_number<255>{}))::value; \
    static constexpr cs_number<CS_TOKENPASTE2(cs_counter_value, __LINE__) + 1>  \
@@ -483,6 +483,13 @@ class cs_number<0>
          cs_regTrigger(cs_number<CS_TOKENPASTE2(cs_counter_value, __LINE__) + 1>{} ); \
       }  \
 
+#define CS_SIGNAL_2(signalName, ...) \
+      QMetaObject::activate(this, &cs_class::signalName, ##__VA_ARGS__); \
+   }  \
+   CS_SIGNAL_INTERNAL_2(signalName)
+
+#define CS_SIGNAL_DECLARE_2(signalName, ...) \
+   CS_SIGNAL_INTERNAL_2(signalName)
 
 #define CS_SIGNAL_OVERLOAD(signalName, argTypes, ...) \
       QMetaObject::activate(this, static_cast<void (cs_class::*)argTypes>(&cs_class::signalName), ##__VA_ARGS__); \
@@ -879,6 +886,8 @@ class cs_number<0>
 
 #define CORE_CS_SIGNAL_1(access, ...)                          CS_SIGNAL_1(access, __VA_ARGS__)
 #define CORE_CS_SIGNAL_2(signalName, ...)                      CS_SIGNAL_2(signalName, ## __VA_ARGS__)
+#define CORE_CS_SIGNAL_DECLARE_1(access, ...)                  CS_SIGNAL_DECLARE_1(access, __VA_ARGS__)
+#define CORE_CS_SIGNAL_DECLARE_2(signalName, ...)              CS_SIGNAL_DECLARE_2(signalName, ## __VA_ARGS__)
 #define CORE_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)     CS_SIGNAL_OVERLOAD(signalName, argTypes, ## __VA_ARGS__)
 
 #define CORE_CS_INVOKABLE_CONSTRUCTOR_1(access, ...)           CS_INVOKABLE_CONSTRUCTOR_1(access, __VA_ARGS__)
@@ -916,6 +925,8 @@ class cs_number<0>
 
 #define CORE_CS_SIGNAL_1(access, ...)                          Q_DECL_IMPORT __VA_ARGS__;
 #define CORE_CS_SIGNAL_2(signalName, ...)
+#define CORE_CS_SIGNAL_DECLARE_1(access, ...)                  __VA_ARGS__;
+#define CORE_CS_SIGNAL_DECLARE_2(signalName, ...)
 #define CORE_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
 #define CORE_CS_INVOKABLE_CONSTRUCTOR_1(access, ...)           __VA_ARGS__;

--- a/src/core/kernel/qcoreapplication.cpp
+++ b/src/core/kernel/qcoreapplication.cpp
@@ -2293,5 +2293,13 @@ bool QCoreApplication::hasPendingEvents()
    return false;
 }
 
+void QCoreApplication::aboutToQuit() {
+  QMetaObject::activate(this, &cs_class::aboutToQuit);
+}
+
+void QCoreApplication::unixSignal(int un_named_arg1) {
+  QMetaObject::activate(this, &cs_class::unixSignal, un_named_arg1);
+}
+
 
 QT_END_NAMESPACE

--- a/src/core/kernel/qcoreapplication.h
+++ b/src/core/kernel/qcoreapplication.h
@@ -164,11 +164,11 @@ class Q_CORE_EXPORT QCoreApplication : public QObject
    CORE_CS_SLOT_1(Public, static void quit())
    CORE_CS_SLOT_2(quit)
 
-   CORE_CS_SIGNAL_1(Public, void aboutToQuit())
-   CORE_CS_SIGNAL_2(aboutToQuit)
+   CORE_CS_SIGNAL_DECLARE_1(Public, void aboutToQuit())
+   CORE_CS_SIGNAL_DECLARE_2(aboutToQuit)
 
-   CORE_CS_SIGNAL_1(Public, void unixSignal(int un_named_arg1))
-   CORE_CS_SIGNAL_2(unixSignal, un_named_arg1)
+   CORE_CS_SIGNAL_DECLARE_1(Public, void unixSignal(int un_named_arg1))
+   CORE_CS_SIGNAL_DECLARE_2(unixSignal, un_named_arg1)
 
  protected:
    bool event(QEvent *);

--- a/src/core/kernel/qobject.cpp
+++ b/src/core/kernel/qobject.cpp
@@ -1618,5 +1618,13 @@ QMap<std::type_index, QMetaObject *> &CSGadget_Fake_Parent::m_metaObjectsAll()
    return metaObjects;
 }
 
+void QObject::destroyed(QObject *obj) {
+  QMetaObject::activate(this, &cs_class::destroyed, obj);
+}
+
+void QObject::objectNameChanged(const QString &objectName) {
+  QMetaObject::activate(this, &cs_class::objectNameChanged, objectName);
+}
+
 
 QT_END_NAMESPACE

--- a/src/core/kernel/qobject.h
+++ b/src/core/kernel/qobject.h
@@ -202,11 +202,11 @@ class Q_CORE_EXPORT QObject
    template<class T>
    T property(const char *name) const;
 
-   CORE_CS_SIGNAL_1(Public, void destroyed(QObject *obj = 0))
-   CORE_CS_SIGNAL_2(destroyed, obj)
+   CORE_CS_SIGNAL_DECLARE_1(Public, void destroyed(QObject *obj = 0))
+   CORE_CS_SIGNAL_DECLARE_2(destroyed, obj)
 
-   CORE_CS_SIGNAL_1(Public, void objectNameChanged(const QString &objectName))
-   CORE_CS_SIGNAL_2(objectNameChanged, objectName)
+   CORE_CS_SIGNAL_DECLARE_1(Public, void objectNameChanged(const QString &objectName))
+   CORE_CS_SIGNAL_DECLARE_2(objectNameChanged, objectName)
 
    CORE_CS_SLOT_1(Public, void deleteLater())
    CORE_CS_SLOT_2(deleteLater)

--- a/src/core/thread/qthread.cpp
+++ b/src/core/thread/qthread.cpp
@@ -651,5 +651,17 @@ QThreadPrivate *QThreadPrivate::cs_getPrivate(QThread *object)
    return object->d_ptr.data();
 }
 
+void QThread::started() {
+  QMetaObject::activate(this, &cs_class::started);
+}
+
+void QThread::finished() {
+  QMetaObject::activate(this, &cs_class::finished);
+}
+
+void QThread::terminated() {
+  QMetaObject::activate(this, &cs_class::terminated);
+}
+
 
 QT_END_NAMESPACE

--- a/src/core/thread/qthread.h
+++ b/src/core/thread/qthread.h
@@ -89,12 +89,12 @@ class Q_CORE_EXPORT QThread : public QObject
    static void msleep(unsigned long);
    static void usleep(unsigned long);
 
-   CORE_CS_SIGNAL_1(Public, void started())
-   CORE_CS_SIGNAL_2(started)
-   CORE_CS_SIGNAL_1(Public, void finished())
-   CORE_CS_SIGNAL_2(finished)
-   CORE_CS_SIGNAL_1(Public, void terminated())
-   CORE_CS_SIGNAL_2(terminated)
+   CORE_CS_SIGNAL_DECLARE_1(Public, void started())
+   CORE_CS_SIGNAL_DECLARE_2(started)
+   CORE_CS_SIGNAL_DECLARE_1(Public, void finished())
+   CORE_CS_SIGNAL_DECLARE_2(finished)
+   CORE_CS_SIGNAL_DECLARE_1(Public, void terminated())
+   CORE_CS_SIGNAL_DECLARE_2(terminated)
 
  protected:
    virtual void run();


### PR DESCRIPTION
For MSVC to correctly substitute template parameters for activate(), it
needs activate to be fully defined before instantiation. This only
impacts types which have signals and are used by activate(). So, this
changes those types to only declare signals and define them in .cpp
files.
