### PR TITLE
Add support for DragonFly BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     )
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD)")
+if(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD|DragonFly)")
     # required by core component
     find_package(Threads)
     set_package_properties(Threads PROPERTIES

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ case "$target" in
 	OSTYPE=LINUX ;;
 *-*-darwin*)
 	OSTYPE=DARWIN ;;
-*-*-*bsd*)
+*-*-*bsd*|*-*-dragonfly*)
 	OSTYPE=BSD ;;
 esac
 

--- a/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Platform.h
+++ b/src/3rdparty/javascriptcore/JavaScriptCore/wtf/Platform.h
@@ -405,7 +405,7 @@
 #endif
 
 /* OS(FREEBSD) - FreeBSD */
-#ifdef __FreeBSD__
+#if defined (__FreeBSD__) || defined (__DragonFly__)
 #define WTF_OS_FREEBSD 1
 #endif
 

--- a/src/3rdparty/ptmalloc/malloc.c
+++ b/src/3rdparty/ptmalloc/malloc.c
@@ -1276,7 +1276,7 @@ int mspace_mallopt(int, int);
 #ifndef LACKS_UNISTD_H
 #include <unistd.h>     /* for sbrk */
 #else /* LACKS_UNISTD_H */
-#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__)
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__DragonFly__)
 extern void*     sbrk(ptrdiff_t);
 #endif /* FreeBSD etc */
 #endif /* LACKS_UNISTD_H */

--- a/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.cpp
+++ b/src/3rdparty/webkit/Source/WebKit/qt/Api/qwebpage.cpp
@@ -3781,6 +3781,8 @@ QString QWebPage::userAgentForUrl(const QUrl&) const
 
 #elif defined Q_OS_BSD4
         firstPartTemp += QString::fromLatin1("BSD Four");
+#elif defined Q_OS_DRAGONFLY
+        firstPartTemp += QString::fromLatin1("DragonFly");
 #elif defined Q_OS_FREEBSD
         firstPartTemp += QString::fromLatin1("FreeBSD");
 #elif defined Q_OS_HPUX

--- a/src/core/global/qglobal.h
+++ b/src/core/global/qglobal.h
@@ -178,6 +178,10 @@ QT_USE_NAMESPACE
 #elif defined(__linux__) || defined(__linux)
 #  define Q_OS_LINUX
 
+#elif defined(__DragonFly__)
+#  define Q_OS_DRAGONFLY
+#  define Q_OS_BSD4
+
 #elif defined(__FreeBSD__)
 #  define Q_OS_FREEBSD
 #  define Q_OS_BSD4
@@ -1665,7 +1669,7 @@ Q_CORE_EXPORT int qrand();
 
 
 #if defined (__ELF__)
-#  if defined (Q_OS_LINUX) || defined (Q_OS_SOLARIS) || defined (Q_OS_FREEBSD) || defined (Q_OS_OPENBSD)
+#  if defined (Q_OS_LINUX) || defined (Q_OS_SOLARIS) || defined (Q_OS_FREEBSD) || defined (Q_OS_OPENBSD) || defined (Q_OS_DRAGONFLY)
 #    define Q_OF_ELF
 #  endif
 #endif

--- a/src/core/global/qplatformdefs.h
+++ b/src/core/global/qplatformdefs.h
@@ -280,7 +280,7 @@ typedef enum {
 
 
 // ***********
-#elif defined(Q_OS_FREEBSD) || defined(Q_OS_NETBSD)
+#elif defined(Q_OS_FREEBSD) || defined(Q_OS_NETBSD) || defined(Q_OS_DRAGONFLY)
 
 #include <qplatformposix.h>
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -65,7 +65,7 @@ macro_generate_public("${GUI_PUBLIC_INCLUDES}" QtGui)
 macro_generate_private("${GUI_PRIVATE_INCLUDES}" QtGui)
 macro_generate_misc("${GUI_INCLUDES}" QtGui)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD)")
+if(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD|DragonFly)")
     set(EXTRA_GUI_LIBS
         ${EXTRA_GUI_LIBS}
         ${FONTCONFIG_LIBRARIES}

--- a/src/phonon/CMakeLists.txt
+++ b/src/phonon/CMakeLists.txt
@@ -340,7 +340,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         ${CMAKE_SOURCE_DIR}/src/3rdparty/phonon/ds9
     )
     set(PHONON2_SUFFIX "ds9")
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD)")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD|DragonFly)")
     set(PHONON2_SOURCES
         ${PHONON2_SOURCES}
         ${CMAKE_SOURCE_DIR}/src/3rdparty/phonon/gstreamer/abstractrenderer.cpp

--- a/src/webkit/CMakeLists.txt
+++ b/src/webkit/CMakeLists.txt
@@ -2357,7 +2357,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         ${EXTRA_WEBKIT_LDFLAGS}
         -Wl,-s
     )
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD)")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD|DragonFly)")
     add_definitions(-DXP_UNIX
         -DENABLE_NETSCAPE_PLUGIN_METADATA_CACHE=1
         -DENABLE_NETSCAPE_PLUGIN_API=1


### PR DESCRIPTION
Minimal alternations are required to build Copperspice on DragonFly.