### PR TITLE
specialize the CMake Freetype2 workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,10 @@ cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
 # Silence a warning about rpath on OS X.
 cmake_policy(SET CMP0042 OLD)
 
-# old versions of CMake ship bogus module, always use the custom one
-cmake_policy(SET CMP0017 OLD)
+# old versions of CMake ship bogus Freetype module
+if(CMAKE_MAJOR_VERSION VERSION_LESS "3")
+    cmake_policy(SET CMP0017 OLD)
+endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 

--- a/cmake/modules/FindFreetype.cmake
+++ b/cmake/modules/FindFreetype.cmake
@@ -21,7 +21,7 @@ endif()
 find_path(FREETYPE_INCLUDES
     NAMES
     freetype.h
-    PATH_SUFFIXES freetype2
+    PATH_SUFFIXES freetype2 freetype2/freetype
     HINTS
     $ENV{FREETYPEDIR}/include
     ${PC_FREETYPE_INCLUDEDIR}


### PR DESCRIPTION
this fixes Freetype detection with recent CMake versions (3.4.x/3.5.x and newer) where, as stated in the custom Freetype module, CMake still refers to its module.