### PR TITLE
Fix __declspec(dllimport) on inline functions on MSVC.

### DIFF
--- a/src/core/global/qglobal.h
+++ b/src/core/global/qglobal.h
@@ -682,11 +682,27 @@ constexpr inline const T &qBound(const T &min, const T &val, const T &max)
 
 #endif
 
+#ifndef Q_DECL_EXPORT_INLINE
+#  if defined(Q_CC_MSVC)
+#    define Q_DECL_EXPORT_INLINE
+#  else
+#    define Q_DECL_EXPORT_INLINE    Q_DECL_EXPORT
+#  endif
+#endif
+
 #ifndef Q_DECL_IMPORT
 #  if defined(Q_OS_WIN)
 #    define Q_DECL_IMPORT    __declspec(dllimport)
 #  else
 #    define Q_DECL_IMPORT
+#  endif
+#endif
+
+#ifndef Q_DECL_IMPORT_INLINE
+#  if defined(Q_CC_MSVC)
+#    define Q_DECL_IMPORT_INLINE
+#  else
+#    define Q_DECL_IMPORT_INLINE    Q_DECL_IMPORT
 #  endif
 #endif
 

--- a/src/core/kernel/csobject_macro.h
+++ b/src/core/kernel/csobject_macro.h
@@ -113,7 +113,7 @@ class cs_number<0>
          return cs_number<0>{};   \
       } \
       friend QMetaObject_T<classNameX>; \
-      Q_DECL_EXPORT static const QMetaObject_T<classNameX> & staticMetaObject()   \
+      Q_DECL_EXPORT_INLINE static const QMetaObject_T<classNameX> & staticMetaObject()   \
       { \
          static std::atomic<bool> isCreated(false);                               \
          static std::atomic<QMetaObject_T<classNameX> *> createdObj(nullptr);     \
@@ -141,7 +141,7 @@ class cs_number<0>
             return *newMeta;     \
          } \
       } \
-      Q_DECL_EXPORT virtual const QMetaObject *metaObject() const \
+      Q_DECL_EXPORT_INLINE virtual const QMetaObject *metaObject() const \
       { \
          return &staticMetaObject(); \
       } \
@@ -478,7 +478,7 @@ class cs_number<0>
          \
          cs_regTrigger(cs_number<CS_TOKENPASTE2(cs_counter_value, __LINE__) + 1>{} ); \
       }  \
-   Q_DECL_EXPORT __VA_ARGS__ {   \
+   Q_DECL_EXPORT_INLINE __VA_ARGS__ {   \
       if (this->signalsBlocked()) {          \
          return;                 \
       }
@@ -934,7 +934,7 @@ class cs_number<0>
 #define CORE_CS_SLOT_2(slotName)
 #define CORE_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define CORE_CS_SIGNAL_1(access, ...)                          Q_DECL_IMPORT __VA_ARGS__;
+#define CORE_CS_SIGNAL_1(access, ...)                          Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define CORE_CS_SIGNAL_2(signalName, ...)
 #define CORE_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1010,7 +1010,7 @@ class cs_number<0>
 #define GUI_CS_SLOT_2(slotName)
 #define GUI_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define GUI_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define GUI_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define GUI_CS_SIGNAL_2(signalName, ...)
 #define GUI_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1060,7 +1060,7 @@ class cs_number<0>
 #define MULTI_CS_SLOT_2(slotName)
 #define MULTI_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define MULTI_CS_SIGNAL_1(access, ...)                             Q_DECL_IMPORT __VA_ARGS__;
+#define MULTI_CS_SIGNAL_1(access, ...)                            Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define MULTI_CS_SIGNAL_2(signalName, ...)
 #define MULTI_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1113,7 +1113,7 @@ class cs_number<0>
 #define NET_CS_SLOT_2(slotName)
 #define NET_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define NET_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define NET_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define NET_CS_SIGNAL_2(signalName, ...)
 #define NET_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1166,7 +1166,7 @@ class cs_number<0>
 #define OPENGL_CS_SLOT_2(slotName)
 #define OPENGL_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define OPENGL_CS_SIGNAL_1(access, ...)                           Q_DECL_IMPORT __VA_ARGS__;
+#define OPENGL_CS_SIGNAL_1(access, ...)                           Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define OPENGL_CS_SIGNAL_2(signalName, ...)
 #define OPENGL_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1219,7 +1219,7 @@ class cs_number<0>
 #define PHN_CS_SLOT_2(slotName)
 #define PHN_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define PHN_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define PHN_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define PHN_CS_SIGNAL_2(signalName, ...)
 #define PHN_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1270,7 +1270,7 @@ class cs_number<0>
 #define SCRIPT_CS_SLOT_2(slotName)
 #define SCRIPT_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define SCRIPT_CS_SIGNAL_1(access, ...)                           Q_DECL_IMPORT __VA_ARGS__;
+#define SCRIPT_CS_SIGNAL_1(access, ...)                           Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define SCRIPT_CS_SIGNAL_2(signalName, ...)
 #define SCRIPT_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1300,7 +1300,7 @@ class cs_number<0>
 #define SCRIPT_T_CS_SLOT_2(slotName)
 #define SCRIPT_T_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define SCRIPT_T_CS_SIGNAL_1(access, ...)                          Q_DECL_IMPORT __VA_ARGS__;
+#define SCRIPT_T_CS_SIGNAL_1(access, ...)                          Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define SCRIPT_T_CS_SIGNAL_2(signalName, ...)
 #define SCRIPT_T_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1330,7 +1330,7 @@ class cs_number<0>
 #define SQL_CS_SLOT_2(slotName)
 #define SQL_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define SQL_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define SQL_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define SQL_CS_SIGNAL_2(signalName, ...)
 #define SQL_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1379,7 +1379,7 @@ class cs_number<0>
 #define SVG_CS_SLOT_OVERLOAD(slotName, argTypes)
 #define SVG_CS_SLOT_OVERLOAD_BOOL(slotName, argTypes)
 
-#define SVG_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define SVG_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define SVG_CS_SIGNAL_2(signalName, ...)
 #define SVG_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1426,7 +1426,7 @@ class cs_number<0>
 #define XMLP_CS_SLOT_2(slotName)
 #define XMLP_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define XMLP_CS_SIGNAL_1(access, ...)                             Q_DECL_IMPORT __VA_ARGS__;
+#define XMLP_CS_SIGNAL_1(access, ...)                             Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define XMLP_CS_SIGNAL_2(signalName, ...)
 #define XMLP_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1479,7 +1479,7 @@ class cs_number<0>
 #define WEB_CS_SLOT_2(slotName)
 #define WEB_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define WEB_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define WEB_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define WEB_CS_SIGNAL_2(signalName, ...)
 #define WEB_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1559,7 +1559,7 @@ class cs_number<0>
 #define DECL_CS_SLOT_2(slotName)
 #define DECL_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define DECL_CS_SIGNAL_1(access, ...)                             Q_DECL_IMPORT __VA_ARGS__;
+#define DECL_CS_SIGNAL_1(access, ...)                             Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define DECL_CS_SIGNAL_2(signalName, ...)
 #define DECL_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1614,7 +1614,7 @@ class cs_number<0>
 #define GSTRM_CS_SLOT_2(slotName)
 #define GSTRM_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define GSTRM_CS_SIGNAL_1(access, ...)                            Q_DECL_IMPORT __VA_ARGS__;
+#define GSTRM_CS_SIGNAL_1(access, ...)                            Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define GSTRM_CS_SIGNAL_2(signalName, ...)
 #define GSTRM_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1645,7 +1645,7 @@ class cs_number<0>
 #define DS9_CS_SLOT_2(slotName)
 #define DS9_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define DS9_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define DS9_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define DS9_CS_SIGNAL_2(signalName, ...)
 #define DS9_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 
@@ -1676,7 +1676,7 @@ class cs_number<0>
 #define QT7_CS_SLOT_2(slotName)
 #define QT7_CS_SLOT_OVERLOAD(slotName, argTypes)
 
-#define QT7_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT __VA_ARGS__;
+#define QT7_CS_SIGNAL_1(access, ...)                              Q_DECL_IMPORT_INLINE __VA_ARGS__;
 #define QT7_CS_SIGNAL_2(signalName, ...)
 #define QT7_CS_SIGNAL_OVERLOAD(signalName, argTypes, ...)
 


### PR DESCRIPTION
If a type is declared with dllimport, functions in that class cannot be
declared dllimport, with MSVC.
