### PR TITLE
Fixed infinite recursion in QTextStream::operator<<().

### DIFF
--- a/src/core/io/qtextstream.cpp
+++ b/src/core/io/qtextstream.cpp
@@ -2192,7 +2192,7 @@ void QTextStreamPrivate::putNumber(qulonglong number, bool negative)
 */
 QTextStream &QTextStream::operator<<(bool b)
 {
-   return *this << bool(b);
+   return *this << int(b);
 }
 
 /*!


### PR DESCRIPTION
I assumed, that outputting bool should result in '0' or '1' being written to the output.