### PR TITLE
Fixed 2 bugs, improved conformance with C++ standard

### DIFF
--- a/src/core/signal/rcu_list.hpp
+++ b/src/core/signal/rcu_list.hpp
@@ -15,6 +15,7 @@
 #define LIBGUARDED_RCU_LIST_HPP
 
 #include <atomic>
+#include <cstddef>
 #include <memory>
 #include <mutex>
 
@@ -48,7 +49,7 @@ class rcu_list
   public:
     using value_type      = T;
     using allocator_type  = Alloc;
-    using size_type       = ssize_t;
+    using size_type       = std::ptrdiff_t;
     using reference       = value_type &;
     using const_reference = const value_type &;
     using pointer         = typename std::allocator_traits<Alloc>::pointer;
@@ -312,7 +313,7 @@ class rcu_list<T, M, Alloc>::iterator
     friend rcu_list<T, M, Alloc>;
     friend rcu_list<T, M, Alloc>::const_iterator;
 
-    explicit iterator(const rcu_list<T, M, Alloc>::const_iterator &it)
+    explicit iterator(const typename rcu_list<T, M, Alloc>::const_iterator &it)
        : m_current(it.m_current)
     {
     }
@@ -342,7 +343,7 @@ class rcu_list<T, M, Alloc>::const_iterator
     {
     }
 
-    const_iterator(const rcu_list<T, M, Alloc>::iterator &it)
+    const_iterator(const typename rcu_list<T, M, Alloc>::iterator &it)
       : m_current(it.m_current)
     {
     }

--- a/src/core/string/cs_string.h
+++ b/src/core/string/cs_string.h
@@ -15,6 +15,7 @@
 #define LIB_CS_STRING_H
 
 #include <algorithm>
+#include <cstddef>
 #include <exception>
 #include <iterator>
 #include <stdexcept>
@@ -38,7 +39,7 @@ template <typename E, typename A>
 class CsBasicString
 {
    public:
-      using size_type      = ssize_t;
+      using size_type      = std::ptrdiff_t;
       using const_iterator = CsStringIterator<E, A>;
       using iterator       = CsStringIterator<E, A>;
 
@@ -946,8 +947,9 @@ CsBasicString<E, A> &CsBasicString<E, A>::assign(Iterator begin, Iterator end)
 template <typename E, typename A>
 CsChar CsBasicString<E, A>::at(size_type index) const
 {
-   const_iterator iter = std::advance(begin(), index);
-   return *iter;
+    const_iterator iter = begin();
+    std::advance(iter, index);
+    return *iter;
 }
 
 template <typename E, typename A>

--- a/src/core/string/cs_string_iterator.h
+++ b/src/core/string/cs_string_iterator.h
@@ -14,6 +14,7 @@
 #ifndef LIB_CS_STRING_ITERATOR_H
 #define LIB_CS_STRING_ITERATOR_H
 
+#include <cstddef>
 #include <vector>
 
 #include <cs_char.h>
@@ -26,7 +27,7 @@ class LIB_CS_STRING_EXPORT CsStringIterator
    using v_iter = typename std::vector<typename E::storage_unit, A>::const_iterator;
 
    public:
-      using size_type         = ssize_t;
+      using size_type         = std::ptrdiff_t;
       using difference_type   = int;
       using value_type        = CsChar;
       using pointer           = CsChar *;

--- a/src/core/string/qstring8.h
+++ b/src/core/string/qstring8.h
@@ -23,6 +23,8 @@
 #ifndef QSTRING8_H
 #define QSTRING8_H
 
+#include <cstddef>
+
 #include <cs_string.h>
 
 #include <qchar32.h>
@@ -39,8 +41,8 @@ class Q_CORE_EXPORT QString8 : public CsString::CsString
       using Iterator        = iterator;
       using ConstIterator   = const_iterator;
 
-      using difference_type = ssize_t;
-      using size_type       = ssize_t;
+      using difference_type = std::ptrdiff_t;
+      using size_type       = std::ptrdiff_t;
       using value_type      = QChar32;
 
       // broom, following four iterators need to return an iterator to a QChar32

--- a/src/core/tools/qvector.h
+++ b/src/core/tools/qvector.h
@@ -247,11 +247,11 @@ class QVector
    }
 
    void push_front(const T &value) {
-      m_data.push_front(value);
+      m_data.insert(m_data.begin(), value);
    }
 
    void push_front(T &&value) {
-      m_data.push_front(std::move(value));
+      m_data.insert(m_data.begin(), std::move(value));
    }
 
    void remove(size_type i) {


### PR DESCRIPTION
- Fixed bug in CsString.at(): std::advance() returns void.
- Fixed bug in QVector::push_front(): std::vector does not have push_front() method.
- Using std::ptrdiff_t instead of ssize_t.
- Added missing typename keywords.