### PR TITLE
Making Q_PACKED portable across compilers

### DIFF
--- a/src/core/global/qglobal.h
+++ b/src/core/global/qglobal.h
@@ -261,8 +261,8 @@ QT_USE_NAMESPACE
 #    define Q_ALIGNOF(type)   __alignof__(type)
 #    define Q_LIKELY(expr)    __builtin_expect(!!(expr), true)
 #    define Q_UNLIKELY(expr)  __builtin_expect(!!(expr), false)
-#    define Q_PACKED          __attribute__ ((__packed__))
-
+#    define Q_PACKED_BEGIN    _Pragma("pack(push, 1)")
+#    define Q_PACKED_END      _Pragma("pack(pop)")
 #    define Q_NO_PACKED_REFERENCE
 
 #    ifndef __ARM_EABI__
@@ -299,7 +299,8 @@ QT_USE_NAMESPACE
 #  define Q_UNLIKELY(expr)  __builtin_expect(!!(expr), false)
 
 #  if (defined(Q_CC_GNU) || defined(Q_CC_INTEL))
-#    define Q_PACKED __attribute__ ((__packed__))
+#    define Q_PACKED_BEGIN  _Pragma("pack(push, 1)")
+#    define Q_PACKED_END    _Pragma("pack(pop)")
 #    define Q_NO_PACKED_REFERENCE
 
 #    ifndef __ARM_EABI__
@@ -356,8 +357,9 @@ QT_USE_NAMESPACE
 
 #endif
 
-#ifndef Q_PACKED
-#  define Q_PACKED
+#ifndef Q_PACKED_BEGIN
+#  define Q_PACKED_BEGIN
+#  define Q_PACKED_END
 #  undef Q_NO_PACKED_REFERENCE
 #endif
 

--- a/src/core/tools/qchar.h
+++ b/src/core/tools/qchar.h
@@ -45,6 +45,10 @@ struct QLatin1Char {
 };
 
 
+#if (defined(__arm__) && defined(QT_NO_ARM_EABI))
+Q_PACKED_BEGIN
+#endif
+
 class Q_CORE_EXPORT QChar
 {
  public:
@@ -317,12 +321,12 @@ class Q_CORE_EXPORT QChar
 
  private:
    ushort ucs;
-}
+};
 
 #if (defined(__arm__) && defined(QT_NO_ARM_EABI))
-Q_PACKED
+Q_PACKED_END
 #endif
-;
+
 
 Q_DECLARE_TYPEINFO(QChar, Q_MOVABLE_TYPE);
 

--- a/src/core/tools/qlocale.h
+++ b/src/core/tools/qlocale.h
@@ -791,14 +791,16 @@ class Q_CORE_EXPORT QLocale
 
    QString createSeparatedList(const QStringList &strl) const;
    //private:                        // this should be private, but can't be
+#if (defined(__arm__) || defined(QT_NO_ARM_EABI))
+   Q_PACKED_BEGIN
+#endif
    struct Data {
       quint16 index;
       quint16 numberOptions;
-   }
+   };
 #if (defined(__arm__) || defined(QT_NO_ARM_EABI))
-   Q_PACKED
+   Q_PACKED_END
 #endif
-   ;
 
  private:
    friend struct QLocalePrivate;

--- a/src/gui/embedded/qscreen_qws.cpp
+++ b/src/gui/embedded/qscreen_qws.cpp
@@ -857,9 +857,11 @@ static void blit_8(QScreen *screen, const QImage &image,
 
 #ifdef QT_QWS_DEPTH_4
 
+Q_PACKED_BEGIN
 struct qgray4 {
    quint8 dummy;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 template <typename SRC>
 Q_STATIC_TEMPLATE_FUNCTION inline quint8 qt_convertToGray4(SRC color);
@@ -1005,9 +1007,11 @@ static void blit_4(QScreen *screen, const QImage &image,
 
 #ifdef QT_QWS_DEPTH_1
 
+Q_PACKED_BEGIN
 struct qmono {
    quint8 dummy;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 template <typename SRC>
 Q_STATIC_TEMPLATE_FUNCTION inline quint8 qt_convertToMono(SRC color);

--- a/src/gui/painting/qdrawhelper_p.h
+++ b/src/gui/painting/qdrawhelper_p.h
@@ -657,6 +657,7 @@ inline quint16 qt_colorConvert(quint32 color, quint16 dummy)
    return (r & 0xf800) | (g & 0x07e0) | (b & 0x001f);
 }
 
+Q_PACKED_BEGIN
 class quint32p
 {
  public:
@@ -679,8 +680,10 @@ class quint32p
  private:
    quint32p() {}
    quint32 data;
-} Q_PACKED;
+};
+Q_PACKED_END
 
+Q_PACKED_BEGIN
 class qabgr8888
 {
  public:
@@ -694,10 +697,12 @@ class qabgr8888
 
  private:
    quint32 data;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 class qrgb565;
 
+Q_PACKED_BEGIN
 class qargb8565
 {
  public:
@@ -740,8 +745,10 @@ class qargb8565
    friend class qrgb565;
 
    quint8 data[3];
-} Q_PACKED;
+};
+Q_PACKED_END
 
+Q_PACKED_BEGIN
 class qrgb565
 {
  public:
@@ -784,7 +791,8 @@ class qrgb565
    friend class qargb8565;
 
    quint16 data;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 qargb8565::qargb8565(quint32 v)
 {
@@ -926,6 +934,7 @@ bool qrgb565::operator==(const qrgb565 &v) const
    return data == v.data;
 }
 
+Q_PACKED_BEGIN
 class qbgr565
 {
  public:
@@ -941,10 +950,12 @@ class qbgr565
 
  private:
    quint16 data;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 class qrgb555;
 
+Q_PACKED_BEGIN
 class qargb8555
 {
  public:
@@ -984,8 +995,10 @@ class qargb8555
  private:
    friend class qrgb555;
    quint8 data[3];
-} Q_PACKED;
+};
+Q_PACKED_END
 
+Q_PACKED_BEGIN
 class qrgb555
 {
  public:
@@ -1066,7 +1079,8 @@ class qrgb555
    friend class qbgr555;
    quint16 data;
 
-} Q_PACKED;
+};
+Q_PACKED_END
 
 qrgb555::qrgb555(const qargb8555 &v)
 {
@@ -1090,6 +1104,7 @@ qrgb555 qrgb555::byte_mul(quint8 a) const
    return result;
 }
 
+Q_PACKED_BEGIN
 class qbgr555
 {
  public:
@@ -1109,7 +1124,8 @@ class qbgr555
 
  private:
    quint16 data;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 qargb8555::qargb8555(quint32 v)
 {
@@ -1199,6 +1215,7 @@ qargb8555 qargb8555::byte_mul(quint8 a) const
 
 class qrgb666;
 
+Q_PACKED_BEGIN
 class qargb6666
 {
  public:
@@ -1237,8 +1254,10 @@ class qargb6666
    friend class qrgb666;
    quint8 data[3];
 
-} Q_PACKED;
+};
+Q_PACKED_END
 
+Q_PACKED_BEGIN
 class qrgb666
 {
  public:
@@ -1281,7 +1300,8 @@ class qrgb666
    friend class qargb6666;
 
    quint8 data[3];
-} Q_PACKED;
+};
+Q_PACKED_END
 
 qrgb666::qrgb666(quint32 v)
 {
@@ -1418,6 +1438,7 @@ quint32 qargb6666::rawValue() const
    return (data[2] << 16) | (data[1] << 8) | data[0];
 }
 
+Q_PACKED_BEGIN
 class qrgb888
 {
  public:
@@ -1452,7 +1473,8 @@ class qrgb888
  private:
    uchar data[3];
 
-} Q_PACKED;
+};
+Q_PACKED_END
 
 qrgb888::qrgb888(quint32 v)
 {
@@ -1548,6 +1570,7 @@ inline quint8 qt_colorConvert(quint16 color, quint8 dummy)
 #endif // QT_QWS_DEPTH_8
 
 // hw: endianess??
+Q_PACKED_BEGIN
 class quint24
 {
  public:
@@ -1569,7 +1592,8 @@ class quint24
 
  private:
    uchar data[3];
-} Q_PACKED;
+};
+Q_PACKED_END
 
 template <>
 inline quint24 qt_colorConvert(quint32 color, quint24 dummy)
@@ -1579,6 +1603,7 @@ inline quint24 qt_colorConvert(quint32 color, quint24 dummy)
 }
 
 // hw: endianess??
+Q_PACKED_BEGIN
 class quint18
 {
  public:
@@ -1601,7 +1626,8 @@ class quint18
 
  private:
    uchar data[3];
-} Q_PACKED;
+};
+Q_PACKED_END
 
 template <>
 inline quint18 qt_colorConvert(quint32 color, quint18 dummy)
@@ -1612,6 +1638,7 @@ inline quint18 qt_colorConvert(quint32 color, quint18 dummy)
 
 class qrgb444;
 
+Q_PACKED_BEGIN
 class qargb4444
 {
  public:
@@ -1657,8 +1684,10 @@ class qargb4444
    friend class qrgb444;
    quint16 data;
 
-} Q_PACKED;
+};
+Q_PACKED_END
 
+Q_PACKED_BEGIN
 class qrgb444
 {
  public:
@@ -1703,8 +1732,8 @@ class qrgb444
    friend class qargb4444;
    quint16 data;
 
-} Q_PACKED;
-
+};
+Q_PACKED_END
 
 qargb4444::qargb4444(quint32p color)
 {
@@ -1812,6 +1841,7 @@ qrgb444 qrgb444::byte_mul(quint8 a) const
 
 #ifdef QT_QWS_DEPTH_GENERIC
 
+Q_PACKED_BEGIN
 struct qrgb {
  public:
    static int bpp;
@@ -1823,7 +1853,8 @@ struct qrgb {
    static int off_green;
    static int off_blue;
    static int off_alpha;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 template <typename SRC>
 Q_STATIC_TEMPLATE_FUNCTION inline quint32 qt_convertToRgb(SRC color);
@@ -1849,6 +1880,7 @@ inline quint32 qt_convertToRgb(quint16 color)
    return qt_convertToRgb(qt_colorConvert<quint32, quint16>(color, 0));
 }
 
+Q_PACKED_BEGIN
 class qrgb_generic16
 {
  public:
@@ -1870,7 +1902,8 @@ class qrgb_generic16
 
  private:
    quint16 data;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 template <>
 inline qrgb_generic16 qt_colorConvert(quint32 color, qrgb_generic16 dummy)

--- a/src/gui/painting/qmemrotate.cpp
+++ b/src/gui/painting/qmemrotate.cpp
@@ -553,6 +553,7 @@ QT_IMPL_MEMROTATE(quint32, qrgb_generic16)
 QT_IMPL_MEMROTATE(quint16, qrgb_generic16)
 #endif
 
+Q_PACKED_BEGIN
 struct qrgb_gl_rgba {
  public:
    inline qrgb_gl_rgba(quint32 v) {
@@ -569,7 +570,8 @@ struct qrgb_gl_rgba {
 
  private:
    quint32 data;
-} Q_PACKED;
+};
+Q_PACKED_END
 
 void Q_GUI_EXPORT qt_memrotate90_gl(const quint32 *src, int srcWidth, int srcHeight, int srcStride,
                                     quint32 *dest, int dstStride)

--- a/src/gui/text/qfontengine_qpa_p.h
+++ b/src/gui/text/qfontengine_qpa_p.h
@@ -99,7 +99,9 @@ class Q_GUI_EXPORT QFontEngineQPA : public QFontEngine
       GlyphBlock
    };
 
-   struct Q_PACKED Header {
+   Q_PACKED_BEGIN
+   
+   struct Header {
       char magic[4]; // 'QPF2'
       quint32 lock;  // values: 0 = unlocked, 0xffffffff = read-only, otherwise qws client id of locking process
       quint8 majorVersion;
@@ -107,13 +109,13 @@ class Q_GUI_EXPORT QFontEngineQPA : public QFontEngine
       quint16 dataSize;
    };
 
-   struct Q_PACKED Block {
+   struct Block {
       quint16 tag;
       quint16 pad;
       quint32 dataSize;
    };
 
-   struct Q_PACKED Glyph {
+   struct Glyph {
       quint8 width;
       quint8 height;
       quint8 bytesPerLine;
@@ -121,6 +123,8 @@ class Q_GUI_EXPORT QFontEngineQPA : public QFontEngine
       qint8 y;
       qint8 advance;
    };
+
+   Q_PACKED_END
 
    QFontEngineQPA(const QFontDef &def, const QByteArray &data);
    ~QFontEngineQPA();

--- a/src/gui/text/qfontengine_qpf_p.h
+++ b/src/gui/text/qfontengine_qpf_p.h
@@ -103,7 +103,9 @@ class Q_GUI_EXPORT QFontEngineQPF : public QFontEngine
       GlyphBlock
    };
 
-   struct Q_PACKED Header {
+   Q_PACKED_BEGIN
+   
+   struct Header {
       char magic[4]; // 'QPF2'
       quint32 lock;  // values: 0 = unlocked, 0xffffffff = read-only, otherwise qws client id of locking process
       quint8 majorVersion;
@@ -111,13 +113,13 @@ class Q_GUI_EXPORT QFontEngineQPF : public QFontEngine
       quint16 dataSize;
    };
 
-   struct Q_PACKED Block {
+   struct Block {
       quint16 tag;
       quint16 pad;
       quint32 dataSize;
    };
 
-   struct Q_PACKED Glyph {
+   struct Glyph {
       quint8 width;
       quint8 height;
       quint8 bytesPerLine;
@@ -125,6 +127,8 @@ class Q_GUI_EXPORT QFontEngineQPF : public QFontEngine
       qint8 y;
       qint8 advance;
    };
+
+   Q_PACKED_END
 
 #ifdef QT_FONTS_ARE_RESOURCES
    QFontEngineQPF(const QFontDef &def, const uchar *bytes, int size);

--- a/src/gui/text/qfontengine_qws.cpp
+++ b/src/gui/text/qfontengine_qws.cpp
@@ -69,7 +69,8 @@ static inline unsigned int getChar(const QChar *str, int &i, const int len)
 #define FM_SMOOTH 1
 
 
-class Q_PACKED QPFGlyphMetrics
+Q_PACKED_BEGIN
+class QPFGlyphMetrics
 {
 
  public:
@@ -90,6 +91,7 @@ class Q_PACKED QPFGlyphMetrics
    //                    delete [] the data when the glyph is deleted.
    enum Flags { RendererOwnsData = 0x01 };
 };
+Q_PACKED_END
 
 class QPFGlyph
 {
@@ -106,7 +108,8 @@ class QPFGlyph
    uchar *data;
 };
 
-struct Q_PACKED QPFFontMetrics {
+Q_PACKED_BEGIN
+struct QPFFontMetrics {
    qint8 ascent, descent;
    qint8 leftbearing, rightbearing;
    quint8 maxwidth;
@@ -116,6 +119,7 @@ struct Q_PACKED QPFFontMetrics {
    quint8 underlinewidth;
    quint8 reserved3;
 };
+Q_PACKED_END
 
 
 class QPFGlyphTree

--- a/src/plugins/gfxdrivers/vnc/qscreenvnc_p.h
+++ b/src/plugins/gfxdrivers/vnc/qscreenvnc_p.h
@@ -279,10 +279,13 @@ public:
     void write(QTcpSocket *socket) const;
 
 private:
+    Q_PACKED_BEGIN
     struct Rect {
         quint8 xy;
         quint8 wh;
-    } Q_PACKED rects[8 * 16];
+    };
+    Q_PACKED_END
+    Rect rects[8 * 16];
 
     quint8 numRects;
     QRfbHextileEncoder<SRC> *encoder;

--- a/src/plugins/platforms/vnc/qvncserver.h
+++ b/src/plugins/platforms/vnc/qvncserver.h
@@ -286,10 +286,13 @@ public:
     void write(QTcpSocket *socket) const;
 
 private:
+    Q_PACKED_BEGIN
     struct Rect {
         quint8 xy;
         quint8 wh;
-    } Q_PACKED rects[8 * 16];
+    };
+    Q_PACKED_END
+    Rect rects[8 * 16];
 
     quint8 numRects;
     QRfbHextileEncoder<SRC> *encoder;


### PR DESCRIPTION
Replaced Q_PACKED macro with Q_PACKED_BEGIN and Q_PACKED_END to make it portable across all compilers. Macros were inspired by macros present in LLVM codebase.
This is a step towards supporting MSVC compilation.