### PR TITLE
Fix some bug.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,20 +410,20 @@ install(
       ${CMAKE_BINARY_DIR}/CopperSpiceConfigVersion.cmake
       ${CMAKE_SOURCE_DIR}/cmake/CopperSpiceMacros.cmake
       ${CMAKE_SOURCE_DIR}/cmake/InstallMinGW.cmake
-   DESTINATION cmake/CopperSpice
+   DESTINATION share/CopperSpice
 )
 
 install(EXPORT CopperSpiceLibraryTargets
     NAMESPACE CopperSpice::
     FILE CopperSpiceLibraryTargets.cmake
-    DESTINATION cmake/CopperSpice
+    DESTINATION share/CopperSpice
 )
 
 install(
     EXPORT CopperSpiceBinaryTargets
     NAMESPACE CopperSpice::
     FILE CopperSpiceBinaryTargets.cmake
-    DESTINATION cmake/CopperSpice
+    DESTINATION share/CopperSpice
 )
 
 message("")

--- a/cmake/CopperSpiceConfig.cmake
+++ b/cmake/CopperSpiceConfig.cmake
@@ -57,10 +57,10 @@ foreach(component ${COPPERSPICE_COMPONENTS})
 
     set(COPPERSPICE_LIBRARIES
         ${COPPERSPICE_LIBRARIES}
-        CopperSpice::Cs${component}@BUILD_MAJOR@
+        CopperSpice::Cs${component}@BUILD_ABI@
     )
     set(COPPERSPICE_${uppercomp}_LIBRARIES
-        CopperSpice::Cs${component}@BUILD_MAJOR@
+        CopperSpice::Cs${component}@BUILD_ABI@
     )
 endforeach()
 

--- a/src/gui/kernel/qt_cocoa_helpers_mac.mm
+++ b/src/gui/kernel/qt_cocoa_helpers_mac.mm
@@ -251,15 +251,8 @@ void qt_mac_update_mouseTracking(QWidget *widget)
    [qt_mac_nativeview_for(widget) updateTrackingAreas];
 }
 
-OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage)
+void qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage)
 {
-   // Verbatim copy if HIViewDrawCGImage (as shown on Carbon-Dev)
-   OSStatus err = noErr;
-
-   require_action(inContext != NULL, InvalidContext, err = paramErr);
-   require_action(inBounds != NULL, InvalidBounds, err = paramErr);
-   require_action(inImage != NULL, InvalidImage, err = paramErr);
-
    CGContextSaveGState( inContext );
    CGContextTranslateCTM (inContext, 0, inBounds->origin.y + CGRectGetMaxY(*inBounds));
    CGContextScaleCTM(inContext, 1, -1);
@@ -267,12 +260,6 @@ OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGIm
    CGContextDrawImage(inContext, *inBounds, inImage);
 
    CGContextRestoreGState(inContext);
-
-InvalidImage:
-InvalidBounds:
-InvalidContext:
-
-   return err;
 }
 
 bool qt_mac_checkForNativeSizeGrip(const QWidget *widget)

--- a/src/gui/kernel/qt_cocoa_helpers_mac_p.h
+++ b/src/gui/kernel/qt_cocoa_helpers_mac_p.h
@@ -78,7 +78,7 @@ void qt_mac_showBaseLineSeparator(void * /*OSWindowRef */window, bool show);
 void * /*NSImage */qt_mac_create_nsimage(const QPixmap &pm);
 void qt_mac_update_mouseTracking(QWidget *widget);
 
-OSStatus qt_mac_drawCGImage(CGContextRef cg, const CGRect *inbounds, CGImageRef);
+void qt_mac_drawCGImage(CGContextRef cg, const CGRect *inbounds, CGImageRef);
 bool qt_mac_checkForNativeSizeGrip(const QWidget *widget);
 void qt_dispatchTabletProximityEvent(void * /*NSEvent * */ tabletEvent);
 bool qt_dispatchKeyEventWithCocoa(void * /*NSEvent * */ keyEvent, QWidget *widgetToGetEvent);


### PR DESCRIPTION
The cmake dependent files should be install in ${prefix}/share/CopperSpice.
```
-- Up-to-date: /usr/local/share/CopperSpice/CopperSpiceConfig.cmake
-- Up-to-date: /usr/local/share/CopperSpice/CopperSpiceConfigVersion.cmake
-- Up-to-date: /usr/local/share/CopperSpice/CopperSpiceMacros.cmake
-- Up-to-date: /usr/local/share/CopperSpice/InstallMinGW.cmake
-- Up-to-date: /usr/local/share/CopperSpice/CopperSpiceLibraryTargets.cmake
-- Up-to-date: /usr/local/share/CopperSpice/CopperSpiceLibraryTargets-release.cmake
-- Up-to-date: /usr/local/share/CopperSpice/CopperSpiceBinaryTargets.cmake
-- Up-to-date: /usr/local/share/CopperSpice/CopperSpiceBinaryTargets-release.cmake
```

When I build CopperSpice in macOS 10.13.2 ( Patch has been pr ):

```
copperspice/src/gui/kernel/qt_cocoa_helpers_mac.mm:259:38: error: use of undeclared identifier 'InvalidContext'
   require_action(inContext != NULL, InvalidContext, err = paramErr);
                                     ^
copperspice/src/gui/kernel/qt_cocoa_helpers_mac.mm:260:37: error: use of undeclared identifier
 'InvalidBounds'
   require_action(inBounds != NULL, InvalidBounds, err = paramErr);
                                    ^
copperspice/src/gui/kernel/qt_cocoa_helpers_mac.mm:261:36: error: use of undeclared identifier
 'InvalidImage'
   require_action(inImage != NULL, InvalidImage, err = paramErr);
```

Finally, what is the "copperspice/src/core/global/Info.plist.app", may be to delete it?
```
CMake Error at src/core/cmake_install.cmake:36 (file):
  file INSTALL cannot copy file
  "/Users/Invincible/Documents/Project/copperspice/src/core/global/Info.plist.app"
  to "/usr/local/mac/Info.plist.app".
Call Stack (most recent call first):
  cmake_install.cmake:84 (include)


make: *** [install] Error 1
```