### PR TITLE
CMake: use platform-specific export directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,26 +416,34 @@ configure_file(
     @ONLY
 )
 
+if(APPLE)
+    set(PKG_PREFIX "CopperSpice.framework/Resources")
+elseif(WIN32)
+    set(PKG_PREFIX "cmake/CopperSpice")
+else()
+    set(PKG_PREFIX "${CMAKE_INSTALL_LIBDIR}/cmake/CopperSpice")
+endif()
+
 install(
    FILES
       ${CMAKE_BINARY_DIR}/CopperSpiceConfig.cmake
       ${CMAKE_BINARY_DIR}/CopperSpiceConfigVersion.cmake
       ${CMAKE_SOURCE_DIR}/cmake/CopperSpiceMacros.cmake
       ${CMAKE_SOURCE_DIR}/cmake/InstallMinGW.cmake
-   DESTINATION cmake/CopperSpice
+   DESTINATION ${PKG_PREFIX}
 )
 
 install(EXPORT CopperSpiceLibraryTargets
     NAMESPACE CopperSpice::
     FILE CopperSpiceLibraryTargets.cmake
-    DESTINATION cmake/CopperSpice
+    DESTINATION ${PKG_PREFIX}
 )
 
 install(
     EXPORT CopperSpiceBinaryTargets
     NAMESPACE CopperSpice::
     FILE CopperSpiceBinaryTargets.cmake
-    DESTINATION cmake/CopperSpice
+    DESTINATION ${PKG_PREFIX}
 )
 
 message("")


### PR DESCRIPTION
The location where the library configuration files get installed now
depends on the target system.
The different locations conform to the conventions for Windows, UNIX
and Apple as described in the CMake documentation [1]:

    <prefix>/(cmake|CMake)/                                (W)
    [...]
    <prefix>/(lib/<arch>|lib|share)/cmake/<name>*/         (U)
    [...]
    <prefix>/<name>.framework/Resources/                   (A)

[1] https://cmake.org/cmake/help/latest/command/find_package.html

Signed-off-by: Dennis Menschel <menschel-d@posteo.de>

---

There is currently another open pull request  #63 that tries to fix the same problem, but that solution doesn't take into account the aforementioned platform-specific conventions.
The solution here is basically inspired by libsdl [2] (beginning at line 1774) and has been tested on Linux.

[2] http://hg.libsdl.org/SDL/file/a05a909eeddb/CMakeLists.txt