### PR TITLE
Issue-75: QDockWidget now scaling to fill parent

### DIFF
--- a/src/gui/widgets/qdockarealayout.cpp
+++ b/src/gui/widgets/qdockarealayout.cpp
@@ -2754,6 +2754,7 @@ void QDockAreaLayout::getGrid(QVector<QLayoutStruct> *_ver_struct_list,
 {
    QSize center_hint(0, 0);
    QSize center_min(0, 0);
+   QSize center_max(0, 0);
    const bool have_central = centralWidgetItem != 0 && !centralWidgetItem->isEmpty();
    if (have_central) {
       center_hint = centralWidgetRect.size();
@@ -2761,6 +2762,7 @@ void QDockAreaLayout::getGrid(QVector<QLayoutStruct> *_ver_struct_list,
          center_hint = centralWidgetItem->sizeHint();
       }
       center_min = centralWidgetItem->minimumSize();
+      center_max = centralWidgetItem->maximumSize();
    }
 
    QRect center_rect = rect;
@@ -2846,7 +2848,7 @@ void QDockAreaLayout::getGrid(QVector<QLayoutStruct> *_ver_struct_list,
       left = (tl_significant && bl_significant) ? left_min.height() : 0;
       right = (tr_significant && br_significant) ? right_min.height() : 0;
       ver_struct_list[1].minimumSize = qMax(left, center_min.height(), right);
-      ver_struct_list[1].maximumSize = have_central ? QWIDGETSIZE_MAX : 0;
+      ver_struct_list[1].maximumSize = center_max.height();
       ver_struct_list[1].expansive = have_central;
       ver_struct_list[1].empty = docks[QInternal::LeftDock].isEmpty()
                                  && !have_central
@@ -2868,6 +2870,9 @@ void QDockAreaLayout::getGrid(QVector<QLayoutStruct> *_ver_struct_list,
       for (int i = 0; i < 3; ++i) {
          ver_struct_list[i].sizeHint
             = qMax(ver_struct_list[i].sizeHint, ver_struct_list[i].minimumSize);
+      }
+      if (have_central && ver_struct_list[0].empty && ver_struct_list[2].empty) {
+         ver_struct_list[1].maximumSize = QWIDGETSIZE_MAX;
       }
    }
 
@@ -2906,8 +2911,7 @@ void QDockAreaLayout::getGrid(QVector<QLayoutStruct> *_ver_struct_list,
       top = (tl_significant && tr_significant) ? top_min.width() : 0;
       bottom = (bl_significant && br_significant) ? bottom_min.width() : 0;
       hor_struct_list[1].minimumSize = qMax(top, center_min.width(), bottom);
-
-      hor_struct_list[1].maximumSize = have_central ? QWIDGETSIZE_MAX : 0;
+      hor_struct_list[1].maximumSize = center_max.width();
       hor_struct_list[1].expansive = have_central;
       hor_struct_list[1].empty = !have_central;
       hor_struct_list[1].pos = center_rect.left();
@@ -2927,6 +2931,9 @@ void QDockAreaLayout::getGrid(QVector<QLayoutStruct> *_ver_struct_list,
       for (int i = 0; i < 3; ++i) {
          hor_struct_list[i].sizeHint
             = qMax(hor_struct_list[i].sizeHint, hor_struct_list[i].minimumSize);
+      }
+      if (have_central && hor_struct_list[0].empty && hor_struct_list[2].empty) {
+         hor_struct_list[1].maximumSize = QWIDGETSIZE_MAX;
       }
    }
 }


### PR DESCRIPTION
This was reported on Qt forums as QTBUG-40410
Expanding dockArea does not get additional available space
when using a fixed-size central widget

The issue was marked resolved with the following two commits -

http://code.qt.io/cgit/qt/qtbase.git/commit/?id=2bfee10f3ab8e8e33b2169d735baedcdd9f2b584
QMainWindow: respect the maximum size of the central widget
Make sure the dock widgets get the available space when the
central widget cannot expand any more.
[ChangeLog][QtWidgets][QMainWindow] Dock widgets will now be resized
properly when the central widget has a fixed size.

http://code.qt.io/cgit/qt/qtbase.git/commit/?id=6589fb7e0da291a3d93ff1803d66fb7942bf393e
Workaround for programs depending on previous layout bug
Change 2bfee10f made QDockAreaLayout respect the maximum
size of the central widget. This broke some existing
programs which would set sizePolicy to Fixed on a central
widget without a sizeHint.

This patch restores the old behaviour for the special case
where there are no dock areas. It is highly unlikely that
the intention in this case is to have a very small central
widget with huge blank areas on either side.