### PR TITLE
Resolving a compile issue when QT_NO_STYLE_STYLESHEET is defined

### DIFF
--- a/src/gui/kernel/qtooltip.cpp
+++ b/src/gui/kernel/qtooltip.cpp
@@ -172,11 +172,13 @@ QTipLabel::QTipLabel(const QString &text, QWidget *w)
    reuseTip(text);
 }
 
+#ifndef QT_NO_STYLE_STYLESHEET
 void QTipLabel::styleSheetParentDestroyed()
 {
    setProperty("_q_stylesheet_parent", QVariant());
    styleSheetParent = 0;
 }
+#endif
 
 void QTipLabel::restartExpireTimer()
 {


### PR DESCRIPTION
The function declaration is wrapped correctly in the macro but the definition wasn't.