### PR TITLE
Fix format string parameters

### DIFF
--- a/src/core/kernel/qobject.h
+++ b/src/core/kernel/qobject.h
@@ -412,7 +412,7 @@ T QObject::property(const QString &name) const
    QMetaProperty p = meta->property(id);
 
    if (! p.isReadable()) {
-      qWarning("%s::property() Property \"%s\" is invalid or does not exist", meta->className(), csPrintable(name));
+      qWarning("%s::property() Property \"%s\" is invalid or does not exist", meta->className().data(), csPrintable(name));
    }
 
    return p.read<T>(this);


### PR DESCRIPTION
Passing non-pod objects to format string is illegal.