### PR TITLE
Minor bug fixes that prevented compilation in MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 /utilities/unicode/**/*.Po
 
 /utilities/harfbuzz_fonts/generate_qrc.sh
+/.vs
+/out/build/x64-Debug (default)
+/out/install/x64-Debug (default)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,9 @@ if (NOT GLIB2_FOUND)
    add_definitions(-DQT_NO_GLIB)
 endif()
 
-if (NOT ZLIB_FOUND)
+if (ZLIB_FOUND)
+   include_directories(${ZLIB_INCLUDE_DIRS})
+else ()
    include_directories(${CMAKE_SOURCE_DIR}/src/3rdparty/zlib)
 endif()
 

--- a/src/core/io/qsettings_win.cpp
+++ b/src/core/io/qsettings_win.cpp
@@ -721,7 +721,7 @@ void QWinSettingsPrivate::set(const QString &uKey, const QVariant &value)
 
          for (; iter != l.constEnd(); ++iter) {
 
-            if (iter->isEmpty() || iter->contains('\0')) {
+            if (iter->isEmpty() || iter->contains(QChar32('\0'))) {
                type = REG_BINARY;
                break;
             }
@@ -786,7 +786,7 @@ void QWinSettingsPrivate::set(const QString &uKey, const QVariant &value)
 
          std::wstring tmp = s.toStdWString();
 
-         if (s.contains('\0')) {
+         if (s.contains(QChar32('\0'))) {
             type = REG_BINARY;
 
             regValueBuff.resize(tmp.size() * 2);

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -46,7 +46,6 @@ include_directories(
    ${CMAKE_SOURCE_DIR}/src/3rdparty/freetype/include
    ${CMAKE_SOURCE_DIR}/src/3rdparty/freetype/include/freetype
    ${CMAKE_SOURCE_DIR}/src/3rdparty/harfbuzz/src
-   ${CMAKE_SOURCE_DIR}/src/3rdparty/zlib
    ${CMAKE_SOURCE_DIR}/src/3rdparty/libtiff/libtiff
    ${CMAKE_SOURCE_DIR}/src/3rdparty/libmng
    ${CMAKE_SOURCE_DIR}/src/3rdparty/libpng


### PR DESCRIPTION
Fixed minor bugs that prevented compilation in MSVC 16.8.3 (added external zlib library include dir in cmake, fixed C2668 'QString8::contains': ambiguous call errors in qsettings_win.cpp)