### PR TITLE
Issue #178: Caching of slot/signal indexes doesn't work

### DIFF
--- a/src/gui/graphicsview/qgraphics_item.cpp
+++ b/src/gui/graphicsview/qgraphics_item.cpp
@@ -4940,7 +4940,7 @@ void QGraphicsItem::prepareGeometryChange()
       // Note that this has to be done *after* markDirty to ensure that
       // _q_processDirtyItems is called before _q_emitUpdated.
 
-      const QMetaMethod &metaMethod = d_ptr->scene->metaObject()->method(scenePrivate->changedSignalIndex);
+      const QMetaMethod &metaMethod = d_ptr->scene->metaObject()->method(d_ptr->scene->metaObject()->indexOfSignal("changed(const QList<QRectF> &)"));
 
       if (d_ptr->scene->isSignalConnected(metaMethod) || scenePrivate->views.isEmpty()) {
 

--- a/src/gui/graphicsview/qgraphics_scene_p.h
+++ b/src/gui/graphicsview/qgraphics_scene_p.h
@@ -58,10 +58,6 @@ class QGraphicsScenePrivate
 
    static QGraphicsScenePrivate *get(QGraphicsScene *q);
 
-   int changedSignalIndex;
-   int processDirtyItemsIndex;
-   int polishItemsIndex;
-
    QGraphicsScene::ItemIndexMethod indexMethod;
    QGraphicsSceneIndex *index;
 


### PR DESCRIPTION
Issue #178
Caching of slot/signal indexes doesn't work.

Root Cause
During initialization when the slot/signal indexes are initialized, they are based on the base class' metaObject() but when used later in other functions they are based off of the sub-class' metaObject. The cached index ends up returning the wrong method.

Resolution
Eliminate caching logic and invoke the functions explicitly.