### PR TITLE
add include needed to compiler on macos

### DIFF
--- a/src/plugins/multimedia/mediaservices/avfoundation/mediaplayer/avfvideowindowcontrol.mm
+++ b/src/plugins/multimedia/mediaservices/avfoundation/mediaplayer/avfvideowindowcontrol.mm
@@ -24,6 +24,7 @@
 #include "avfvideowindowcontrol.h"
 
 #include <AVFoundation/AVFoundation.h>
+#include <AppKit/NSView.h>
 
 AVFVideoWindowControl::AVFVideoWindowControl(QObject *parent)
    : QVideoWindowControl(parent)


### PR DESCRIPTION
I have just tried to build copperspice on my m1 macbook pro with bug sur and Xcode 12.4. Almost everything works apart from this include is needed to get the CsMultimedia_avf_mediaplayer to build. Not sure if this works on other versions of macosl