### PR TITLE
Add intersects function to QPolygon and QPolygonF

### DIFF
--- a/src/gui/painting/qpolygon.cpp
+++ b/src/gui/painting/qpolygon.cpp
@@ -468,6 +468,16 @@ QPolygon QPolygon::subtracted(const QPolygon &rectangle) const
    return subject.subtracted(clip).toFillPolygon().toPolygon();
 }
 
+bool QPolygon::intersects(const QPolygon& rectangle) const
+{
+    QPainterPath subject;
+    subject.addPolygon(*this);
+
+    QPainterPath clip;
+    clip.addPolygon(rectangle);
+    return subject.intersects(clip);
+}
+
 QPolygonF QPolygonF::united(const QPolygonF &rectangle) const
 {
    QPainterPath subject;
@@ -498,6 +508,16 @@ QPolygonF QPolygonF::subtracted(const QPolygonF &rectangle) const
    QPainterPath clip;
    clip.addPolygon(rectangle);
    return subject.subtracted(clip).toFillPolygon();
+}
+
+bool QPolygonF::intersects(const QPolygonF &rectangle) const
+{
+    QPainterPath subject; 
+    subject.addPolygon(*this);
+
+    QPainterPath clip; 
+    clip.addPolygon(rectangle);
+    return subject.intersects(clip);
 }
 
 QPolygonF::operator QVariant() const

--- a/src/gui/painting/qpolygon.h
+++ b/src/gui/painting/qpolygon.h
@@ -105,6 +105,7 @@ class Q_GUI_EXPORT QPolygon : public QVector<QPoint>
    QPolygon united(const QPolygon &rectangle) const;
    QPolygon intersected(const QPolygon &rectangle) const;
    QPolygon subtracted(const QPolygon &rectangle) const;
+   bool intersects(const QPolygon &rectangle) const;
 };
 
 inline QPolygon::QPolygon(int asize) : QVector<QPoint>(asize) {}
@@ -204,6 +205,7 @@ class Q_GUI_EXPORT QPolygonF : public QVector<QPointF>
    QPolygonF united(const QPolygonF &rectangle) const;
    QPolygonF intersected(const QPolygonF &rectangle) const;
    QPolygonF subtracted(const QPolygonF &rectangle) const;
+   bool intersects(const QPolygonF &rectangle) const;
 };
 
 inline QPolygonF::QPolygonF(int asize) : QVector<QPointF>(asize) {}


### PR DESCRIPTION
When I port my code form Qt5 to copperspice, I found this function is missing.
So I added the intersects function to QPolygon and QPolygonF.