### PR TITLE
Fixed compilation using gcc-11

### DIFF
--- a/src/core/concurrent/qtconcurrentthreadengine.h
+++ b/src/core/concurrent/qtconcurrentthreadengine.h
@@ -224,7 +224,7 @@ template <>
 class ThreadEngineStarter<void> : public ThreadEngineStarterBase<void>
 {
  public:
-   ThreadEngineStarter<void>(ThreadEngine<void> *_threadEngine)
+   ThreadEngineStarter(ThreadEngine<void> *_threadEngine)
       : ThreadEngineStarterBase<void>(_threadEngine) {}
 
    void startBlocking() {


### PR DESCRIPTION
When linking an application to copperspice 1.7.4 using gcc-11, it gives an error on the specialized template for the ThreadEngineStarter. (See attached image)

![image](https://user-images.githubusercontent.com/12393307/172427998-2121a9e2-8376-489f-8836-f61ffea75239.png)

This was caused by the repeated <void> template argument at the constructor. I've removed this, and now it works with my application. I've also tested using the kitchensink application, which also compiles and links. 