### PR TITLE
Debian package generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY  OFF)
 set(CPACK_SOURCE_PACKAGE_FILE_NAME    "${PROJECT_NAME}-${PACKAGE_VERSION}")
 set(CPACK_SOURCE_GENERATOR            ZIP TBZ2)
 
+file (READ "description.txt" CPACK_PACKAGE_DESCRIPTION_TEXT)
+
 file(STRINGS cmake/dist_ignore.txt    CPACK_SOURCE_IGNORE_FILES)
 
 include(CPack)
@@ -703,6 +705,56 @@ else()
    set(PKG_PREFIX "${CMAKE_INSTALL_LIBDIR}/cmake/CopperSpice")
 
 endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "(Linux|OpenBSD|FreeBSD|NetBSD|DragonFly)")
+    #  Update files needed for Debian
+    #  Note: You need to update CPACK_PACKAGE_INSTALLED_SIZE to reflect current installed size
+    #
+   set(CPACK_PACKAGE_INSTALLED_SIZE "150000")
+
+   # this architecture value is only used on the control file for a debian package.
+   # if the value is bogus or empty on other platforms it simply doesn't matter.
+   #
+   EXECUTE_PROCESS( COMMAND dpkg --print-architecture  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE CPACK_PACKAGE_ARCHITECTURE)
+
+
+   message( STATUS "Architecture: ${CPACK_PACKAGE_ARCHITECTURE}")
+
+
+    configure_file(
+       ${CMAKE_SOURCE_DIR}/deb_build.etc/control.in
+       deb_build.etc/control
+    )
+
+    configure_file(
+       ${CMAKE_SOURCE_DIR}/copperspice.spec.in
+       reddiamond.spec
+    )
+
+    #  postrm has some heavy syntax - just copy
+    configure_file(
+       ${CMAKE_SOURCE_DIR}/deb_build.etc/postrm.in
+       deb_build.etc/postrm
+       COPYONLY
+    )
+
+    #  postinst has some heavy syntax - just copy
+    configure_file(
+       ${CMAKE_SOURCE_DIR}/deb_build.etc/postinst.in
+       deb_build.etc/postinst
+       COPYONLY
+    )
+
+    #  hopefully we never need to replace values in rules
+    configure_file(
+       ${CMAKE_SOURCE_DIR}/deb_build.etc/rules.in
+       deb_build.etc/rules
+       COPYONLY
+    )
+
+endif()
+
+
 
 install(
    FILES

--- a/build-copperspice-deb.sh
+++ b/build-copperspice-deb.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+#
+# Script to build a debian package for CopperSpice
+#
+set -e
+
+if [ ! -f "/etc/debian_version" ]; then
+   if [ ! "$(grep -i 'ID_LIKE=debian' /etc/*release)" ]; then
+      echo "This script can only be run on a Debian based distribution"
+      exit 1
+   fi
+fi
+
+echo "MUST BE RUN FROM ROOT OF PROJECT DIRECTORY TREE"
+echo ""
+echo "MUST have fakeroot, hashdeep, and dpkg-deb installed!"
+echo ""
+echo "This script ASSUMES it can create or use copperspice_debian_build and copperspice_debian_release"
+echo "directories one level up from where this script is being run. If they"
+echo "exist they will be deleted and recreated."
+echo ""
+echo "Script also ASSUMES you are running from the root of the Git directory"
+echo "where all source is in a directory named src at the same level as this file."
+echo ""
+echo "You must have ninja, cmake, and a valid build environment. CopperSpice will be built"
+echo "from source and installed in copperspice_debian_release. We will then create a"
+echo "DEBIAN directory to assemble all files needed for creation of a .deb."
+echo ""
+echo ""
+
+
+#  Step 1 : Establish fresh clean directories
+#
+echo "*** Establishing fresh directories"
+SCRIPT_DIR="$PWD"
+BUILD_DIR="$SCRIPT_DIR/../copperspice_debian_build"
+RELEASE_DIR="$SCRIPT_DIR/../copperspice_debian_release"
+DEBIAN_DIR="$SCRIPT_DIR/../copperspice_debian"
+DEBIAN_WORK_DIR="$SCRIPT_DIR/../copperspice_debian_work"
+
+echo "SCRIPT_DIR  $SCRIPT_DIR"
+echo "BUILD_DIR   $BUILD_DIR"
+echo "RELEASE_DIR $RELEASE_DIR"
+echo "DEBIAN_DIR  $DEBIAN_DIR"
+
+function build_from_source()
+{
+    #  nuke the directories we will use if they already exist
+    #
+    if [ -d "$BUILD_DIR" ]; then
+      rm -rf "$BUILD_DIR"
+    fi
+
+    if [ -d "$RELEASE_DIR" ]; then
+      rm -rf "$RELEASE_DIR"
+    fi
+
+    if [ -d "$DEBIAN_DIR" ]; then
+      rm -rf "$DEBIAN_DIR"
+    fi
+
+    #  create the directories we will use so they are fresh and clean
+    #
+    mkdir -p "$BUILD_DIR"
+    mkdir -p "$RELEASE_DIR"
+    mkdir -p "$DEBIAN_DIR"/DEBIAN
+    mkdir -p "$DEBIAN_DIR"/usr/include/copperspice
+    mkdir -p "$DEBIAN_DIR"/usr/lib/copperspice/bin
+    mkdir -p "$DEBIAN_DIR"/usr/lib/cmake/CopperSpice
+    mkdir -p "$DEBIAN_DIR"/usr/lib/pkgconfig
+    mkdir -p "$DEBIAN_DIR"/usr/share/doc/CopperSpice/license
+
+    #  Step 2 : Prepare build directory
+    #
+    echo "*** Prepping build directory"
+    cd "$BUILD_DIR"
+
+    cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$RELEASE_DIR" \
+        "$SCRIPT_DIR"
+
+    #  Step 4: Actually build CopperSpice
+    #
+    echo "*** Building CopperSpice"
+    ninja install
+
+}
+
+function dev_deb()
+{
+
+    #  Step 5 : Move files to the debian tree
+    #
+    echo "*** Copying files to Debian tree"
+    # deb_build.etc/preinst deb_build.etc/postinst deb_build.etc/prerm
+    cp -f "$BUILD_DIR"/deb_build.etc/control "$BUILD_DIR"/deb_build.etc/postrm "$BUILD_DIR"/deb_build.etc/postinst "$DEBIAN_DIR"/DEBIAN
+    #
+    # Files in this directory need to be marked executable.
+    #
+    chmod 0664 "$DEBIAN_DIR"/DEBIAN/*
+    chmod +x "$DEBIAN_DIR"/DEBIAN/postrm
+    chmod +x "$DEBIAN_DIR"/DEBIAN/postinst
+
+    #  Note: If you want changelog to actually have anything in it, you need to create one
+    #        I put a placeholder in the project for now because I didn't want to
+    #        saddle this build script with git-buildpackage dependencies
+    #
+    cp "$SCRIPT_DIR"/changelog "$DEBIAN_DIR"/usr/share/doc/CopperSpice/changelog.Debian
+    cp -Prv "$SCRIPT_DIR"/license/* "$DEBIAN_DIR"/usr/share/doc/CopperSpice/license/
+
+    cp -Prv "$RELEASE_DIR"/bin/* "$DEBIAN_DIR"/usr/lib/copperspice/bin/
+    cp -Prv "$RELEASE_DIR"/include/* "$DEBIAN_DIR"/usr/include/copperspice/
+    cp -Prv "$RELEASE_DIR"/lib/pkgconfig/* "$DEBIAN_DIR"/usr/lib/pkgconfig
+    cp -Prv "$RELEASE_DIR"/lib/cmake/* "$DEBIAN_DIR"/usr/lib/cmake/CopperSpice/
+    cp -Prv "$RELEASE_DIR"/lib/*.so "$DEBIAN_DIR"/usr/lib/copperspice/
+
+    chmod 0664 "$DEBIAN_DIR"/usr/share/doc/CopperSpice/changelog*
+
+    gzip --best --force "$DEBIAN_DIR"/usr/share/doc/CopperSpice/changelog*
+
+    #  Step 6 : generate md5sum
+    #
+    echo "Generating md5sums"
+    cd "$DEBIAN_DIR"
+    md5deep -r  usr/share/doc/CopperSpice/* 2>/dev/null >DEBIAN/md5sums
+    # don't currently have any pre files
+    # DEBIAN/pre*
+    #
+    chmod go-w DEBIAN/md5sums DEBIAN/post* usr usr/share usr/share/doc usr/share/doc/CopperSpice
+
+    # Step 7 : build .deb
+    #
+    cd ..
+    D_DIR="$PWD"
+    echo "Building .deb IN $D_DIR"
+    fakeroot dpkg-deb -Zgzip --build "$DEBIAN_DIR"
+
+    # Step 8 : rename .deb
+    #          file will be named copperspice_debian.deb and should just be copperspice-version-architecture-dev.deb
+    #
+    D_VERSION=$(grep -i "Version:" "$DEBIAN_DIR"/DEBIAN/control | cut -d' ' -f2)
+    D_ARCH=$(grep -i "Architecture:" "$DEBIAN_DIR"/DEBIAN/control | cut -d' ' -f2)
+    DEB_NAME="copperspice-$D_VERSION-$D_ARCH-dev.deb"
+    echo "look for:  $DEB_NAME"
+
+    mv copperspice_debian.deb "$DEB_NAME"
+
+}
+
+function runtime_deb()
+{
+
+    #  Step 5 : Move files to the debian tree
+    #
+    echo "*** Copying files to Debian tree"
+    # deb_build.etc/preinst deb_build.etc/postinst deb_build.etc/prerm
+    cp -f "$BUILD_DIR"/deb_build.etc/control "$BUILD_DIR"/deb_build.etc/postrm "$BUILD_DIR"/deb_build.etc/postinst "$DEBIAN_DIR"/DEBIAN
+    #
+    # Files in this directory need to be marked executable.
+    #
+    chmod 0664 "$DEBIAN_DIR"/DEBIAN/*
+    chmod +x "$DEBIAN_DIR"/DEBIAN/postrm
+    chmod +x "$DEBIAN_DIR"/DEBIAN/postinst
+
+    #  Note: If you want changelog to actually have anything in it, you need to create one
+    #        I put a placeholder in the project for now because I didn't want to
+    #        saddle this build script with git-buildpackage dependencies
+    #
+    cp "$SCRIPT_DIR"/changelog "$DEBIAN_DIR"/usr/share/doc/CopperSpice/changelog.Debian
+    cp -Prv "$SCRIPT_DIR"/license/* "$DEBIAN_DIR"/usr/share/doc/CopperSpice/license/
+
+    cp -Prv "$RELEASE_DIR"/bin/* "$DEBIAN_DIR"/usr/lib/copperspice/bin/
+    cp -Prv "$RELEASE_DIR"/lib/*.so "$DEBIAN_DIR"/usr/lib/copperspice/
+
+    chmod 0664 "$DEBIAN_DIR"/usr/share/doc/CopperSpice/changelog*
+
+    gzip --best --force "$DEBIAN_DIR"/usr/share/doc/CopperSpice/changelog*
+
+    #  Step 6 : generate md5sum
+    #
+    echo "Generating md5sums"
+    cd "$DEBIAN_DIR"
+    md5deep -r  usr/share/doc/CopperSpice/* 2>/dev/null >DEBIAN/md5sums
+    # don't currently have any pre files
+    # DEBIAN/pre*
+    #
+    chmod go-w DEBIAN/md5sums DEBIAN/post* usr usr/share usr/share/doc usr/share/doc/CopperSpice
+
+    # Step 7 : build .deb
+    #
+    cd ..
+    D_DIR="$PWD"
+    echo "Building .deb IN $D_DIR"
+    fakeroot dpkg-deb -Zgzip --build "$DEBIAN_DIR"
+
+    # Step 8 : rename .deb
+    #          file will be named copperspice_debian.deb and should just be copperspice-version-architecture.deb
+    #
+    D_VERSION=$(grep -i "Version:" "$DEBIAN_DIR"/DEBIAN/control | cut -d' ' -f2)
+    D_ARCH=$(grep -i "Architecture:" "$DEBIAN_DIR"/DEBIAN/control | cut -d' ' -f2)
+    DEB_NAME="copperspice-$D_VERSION-$D_ARCH.deb"
+    echo "look for:  $DEB_NAME"
+
+    mv copperspice_debian.deb "$DEB_NAME"
+
+}
+
+
+#   See if user wants to build everything from source through package
+#   build source only, or build package only from whatever got built already
+#
+BUILD_ALL="Y"
+BUILD_SRC="N"
+RUNTIME_PKG="N"
+DEV_PKG="N"
+
+SRC_BUILD_OPTION="src"
+RUNTIME_OPTION="run"
+DEV_OPTION="dev"
+
+for option in "$@"
+do
+    if [ "${option,,}" = "${SRC_BUILD_OPTION,,}" ]; then
+        BUILD_SRC="Y"
+        BUILD_ALL="N"
+    fi
+
+    if [ "${option,,}" = "${RUNTIME_OPTION,,}" ]; then
+        RUNTIME_PKG="Y"
+        BUILD_ALL="N"
+    fi
+
+    if [ "${option,,}" = "${DEV_OPTION,,}" ]; then
+        DEV_PKG="Y"
+        BUILD_ALL="N"
+    fi
+
+done
+
+if [ "$BUILD_ALL" = "Y" ]; then
+    build_from_source
+    runtime_deb
+    dev_deb
+fi
+
+if [ "$BUILD_SRC" = "Y" ]; then
+    build_from_source
+fi
+
+if [ "$RUNTIME_PKG" = "Y" ]; then
+    runtime_deb
+fi
+
+if [ "$DEV_PKG" = "Y" ]; then
+    dev_deb
+fi
+
+set -e
+
+exit 0

--- a/changelog
+++ b/changelog
@@ -1,0 +1,4 @@
+CopperSpice (0.01-001) unstable; urgency=low
+
+  * Initial Release.  placeholder changelog until we decide what to do
+

--- a/copperspice.spec.in
+++ b/copperspice.spec.in
@@ -1,0 +1,80 @@
+Name:       @PACKAGE@
+Version:    @RPM_VERSION@
+Release:    @RPM_RELEASE@
+Summary:    RedDiamond text editor
+License:    GPL V2 + restriction
+Group:      Applications/Editors
+URL:        https://sourceforge.net/projects/reddiamond/
+Vendor:     @CPACK_PACKAGE_VENDOR@
+Packager:   Roland Hughes <roland@logikalsolutions.com>
+Provides:   libCsCore1.7.so()(64bit), libCsGui1.7.so()(64bit), libCsNetwork1.7.so()(64bit)
+
+
+%description
+@REDDIAMOND_DESCRIPTION@
+
+%prep
+# Cleanup any left over build files
+#
+rm -rf *
+
+# Populate the build directory
+# -DENABLE_RPATH_ORIGIN=ON \
+cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH="@CMAKE_PREFIX_PATH@" \
+      -DCMAKE_INSTALL_PREFIX="%{buildroot}/opt/reddiamond" \
+      "@CMAKE_SOURCE_DIR@"
+
+%build
+ninja
+
+%install
+# This variable gets rid of bogus RPATH error message
+#
+QA_RPATHS=\$[0x0003]
+rm -rf %{buildroot}/opt/reddiamond
+mkdir -p %{buildroot}/opt/reddiamond
+mkdir -p %{buildroot}/usr/local/cs_lib/lib64
+mkdir -p %{buildroot}/usr/local/lib/Lexilla
+cp -Prv /usr/local/cs_lib/lib64/* %{buildroot}/usr/local/cs_lib/lib64/
+cp -Prv /usr/local/lib/Lexilla/* %{buildroot}/usr/local/lib/Lexilla/
+ninja install
+
+%files
+/opt/reddiamond
+/usr/local/cs_lib
+/usr/local/lib/Lexilla
+
+%post
+# no matter install or upgrade, create and copy
+#
+ln -s /opt/reddiamond/reddiamond /usr/local/bin
+#
+# We cannot use RPATH under Fedora and a few other RPM based distros
+#
+echo "/usr/local/cs_lib/lib64" > /etc/ld.so.conf.d/reddiamond_x86_64.conf
+echo "/usr/local/lib/Lexilla" >> /etc/ld.so.conf.d/reddiamond_x86_64.conf
+cp /opt/reddiamond/net.projects.reddiamond.desktop /usr/share/applications
+cp /opt/reddiamond/reddiamond.png /usr/share/pixmaps
+ldconfig
+
+
+%postun
+# No difference between upgrade and uninstall for these
+#
+rm /usr/local/bin/reddiamond
+rm /usr/share/applications/net.projects.reddiamond.desktop
+rm /usr/share/pixmaps/reddiamond.png
+
+if [ $1 -gt 0 ] ; then
+    # removing - need to completely remove the directory
+    rm -rf /opt/reddiamond
+    rm -rf /usr/local/cs_lib
+    rm -rf /usr/local/lib/Lexilla
+    rm /etc/ld.so.conf.d/reddiamond_x86_64.conf
+    ldconfig
+fi
+
+
+%changelog
+# let's skip this for now

--- a/deb_build.etc/control.in
+++ b/deb_build.etc/control.in
@@ -1,0 +1,9 @@
+Package: @CPACK_PACKAGE_NAME@
+Priority: optional
+Section: libs
+Maintainer: @CPACK_PACKAGE_CONTACT@
+Installed-Size: @CPACK_PACKAGE_INSTALLED_SIZE@
+Architecture: @CPACK_PACKAGE_ARCHITECTURE@
+Version: @PACKAGE_VERSION@
+Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4), zlib1g, libopengl0, libxcb-xinerama0, libxcb-xinput0
+Description: @CPACK_PACKAGE_DESCRIPTION_TEXT@

--- a/deb_build.etc/postinst.in
+++ b/deb_build.etc/postinst.in
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+#echo "$0 called with $1"
+
+logger copperspice postinst called with "$1"
+
+
+if [ "$1" != "configure" ]
+then
+    exit 0
+fi
+
+set +e  #cheat to get around lintian complaining about missing -e above
+        #if you don't turn off exit on error the first -f file.name test which
+        #fails to find a file (not a fatal condition, hence our test) fatals out of the script.
+
+ldconfig
+
+set -e
+exit 0

--- a/deb_build.etc/postrm.in
+++ b/deb_build.etc/postrm.in
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+echo "$0 called with $1"
+
+set +e  #cheat to get around lintian complaining about missing -e above
+        #if you don't turn off exit on error the first -f file.name test which
+        #fails to find a file (not a fatal condition, hence our test) fatals out of the script.
+
+    rm -rf /usr/include/copperspice
+    rm -rf /usr/lib/copperspice
+    rm -rf /usr/lib/cmake/CopperSpice
+
+set -e
+
+exit 0

--- a/deb_build.etc/rules.in
+++ b/deb_build.etc/rules.in
@@ -1,0 +1,8 @@
+#!/usr/bin/make -f
+#  need to use TAB instead of spaces here
+#  I honestly don't think we need any rules for this.
+#  Edit this file in a terminal window using nano with
+#  default editor configuration.
+#
+%:
+	dh $@

--- a/description.txt
+++ b/description.txt
@@ -1,0 +1,7 @@
+CopperSpice C++ cross platform GUI library
+ CopperSpice is a set of individual libraries which can be used to develop
+ cross platform software applications in C++. It is a totally open source
+ project released under the LGPL V2.1 license and was initially derived 
+ from the Qt framework. Over the last several years CopperSpice has 
+ completely diverged, with a goal of providing a first class GUI library
+ to unite the C++ community.


### PR DESCRIPTION
We can now perform a full build, generate a run-time debian, and a -dev debian

Everybody needs this so they aren't bundling the run-time with everything they release. I put the /bin under /usr/lib/copperspice just like the AUR package does. When I looked at the cmake files they seem to already support that. Given uic, etc. still have the Qt binary names they cannot be put into /usr/bin.

If you want to see/test a pair of debians made with this,
https://www.dropbox.com/s/pkc9uq0cursps2b/copperspice-1.8.0-amd64-dev.deb?dl=0
https://www.dropbox.com/s/5s0k8yiwkad4j44/copperspice-1.8.0-amd64.deb?dl=0

I need to get RedDiamond and Xpns-It-Cs converted to use this in their debians.

Now everyone wanting to port to CopperSpice can just link back to the debian and list copperspice >= 1.8 in their own Debian package.