### PR TITLE
cmake/pkgconfig.cmake: Pass correct ld -l flag

### DIFF
--- a/cmake/pkgconfig.cmake
+++ b/cmake/pkgconfig.cmake
@@ -25,6 +25,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@PC_REALNAME@
 Name: @PC_NAME@
 Description: @PC_NAME@ library
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -l@PC_NAME@
+Libs: -L${libdir} -l@PC_NAME@@BUILD_ABI@
 Cflags: @PC_CFLAGS@ -I@CMAKE_INSTALL_FULL_INCLUDEDIR@ -I${includedir}
 Requires: @PC_REQUIRES@


### PR DESCRIPTION
The installed libraries are named e.g. libCsCore1.8.so and not libCsCore.so.1.8, so the version number must be included in the name passed to "ld -l".