### PR TITLE
Issue #279: Improve css parsing performance

### DIFF
--- a/src/gui/text/qcssparser_p.h
+++ b/src/gui/text/qcssparser_p.h
@@ -650,10 +650,9 @@ enum TokenType {
 };
 
 struct Symbol {
-   inline Symbol() : token(NONE), start(0), len(-1) {}
+   inline Symbol() : token(NONE) {}
    TokenType token;
    QString text;
-   int start, len;
    Q_GUI_EXPORT QString lexem() const;
 };
 

--- a/src/gui/text/qcssscanner_p.cpp
+++ b/src/gui/text/qcssscanner_p.cpp
@@ -28,22 +28,21 @@ class QCssScanner_Generated
    QCssScanner_Generated(const QString &inp);
 
    inline QChar next() {
-      return (pos < input.length()) ? input.at(pos++) : QChar();
+      return (pos != input.end()) ? *pos++ : QChar();
    }
    int handleCommentStart();
    int lex();
 
-   QString input;
-   int pos;
-   int lexemStart;
+   const QString& input;
+   QString::const_iterator pos;
+   QString::const_iterator lexemStart;
    int lexemLength;
 };
 
-QCssScanner_Generated::QCssScanner_Generated(const QString &inp)
+QCssScanner_Generated::QCssScanner_Generated(const QString &inp) : input(inp)
 {
-   input = inp;
-   pos = 0;
-   lexemStart = 0;
+   pos = input.begin();
+   lexemStart = input.begin();
    lexemLength = 0;
 }
 
@@ -52,7 +51,7 @@ int QCssScanner_Generated::lex()
 {
    lexemStart = pos;
    lexemLength = 0;
-   int lastAcceptingPos = -1;
+   QString::const_iterator lastAcceptingPos = input.end();
    int token = -1;
    QChar ch;
 
@@ -1511,7 +1510,7 @@ found:
    lastAcceptingPos = pos;
 
 out:
-   if (lastAcceptingPos != -1) {
+   if (lastAcceptingPos != input.end()) {
       lexemLength = lastAcceptingPos - lexemStart;
       pos = lastAcceptingPos;
    }

--- a/src/svg/qsvghandler.cpp
+++ b/src/svg/qsvghandler.cpp
@@ -2182,8 +2182,7 @@ void QSvgHandler::parseCSStoXMLAttrs(QString css, QVector<QSvgCssAttribute> *att
          name = QStringView(key);
 
       } else {
-         const QCss::Symbol &sym = m_cssParser.symbol();
-         name = QStringView(sym.text.begin() + sym.start, sym.text.begin() + sym.start + sym.len);
+        name = m_cssParser.symbol().text;
       }
 
       m_cssParser.skipSpace();
@@ -2207,34 +2206,8 @@ void QSvgHandler::parseCSStoXMLAttrs(QString css, QVector<QSvgCssAttribute> *att
          ++symbolCount;
       } while (m_cssParser.hasNext() && !m_cssParser.test(QCss::SEMICOLON));
 
-      bool canExtractValueByRef = !m_cssParser.hasEscapeSequences;
-
-      if (canExtractValueByRef) {
-         int len = m_cssParser.symbols.at(firstSymbol).len;
-
-         for (int i = firstSymbol + 1; i < firstSymbol + symbolCount; ++i) {
-            len += m_cssParser.symbols.at(i).len;
-
-            if (m_cssParser.symbols.at(i - 1).start + m_cssParser.symbols.at(i - 1).len
-                  != m_cssParser.symbols.at(i).start) {
-               canExtractValueByRef = false;
-               break;
-            }
-         }
-         if (canExtractValueByRef) {
-            const QCss::Symbol &sym = m_cssParser.symbols.at(firstSymbol);
-            attribute.value = QStringView(sym.text.begin() + sym.start, sym.text.begin() + sym.start + len);
-         }
-      }
-
-      if (! canExtractValueByRef) {
-         QString value;
-
-         for (int i = firstSymbol; i < m_cssParser.index - 1; ++i) {
-            value += m_cssParser.symbols.at(i).lexem();
-         }
-
-         attribute.value = value;
+      for (int i = firstSymbol; i < m_cssParser.index - 1; ++i) {
+         attribute.value += m_cssParser.symbols.at(i).lexem();
       }
 
       attributes->append(attribute);


### PR DESCRIPTION
Issue #279: Improve css parsing performance

Replace use of indexing with iterators and a few other changes to improve css parsing performance.