### PR TITLE
Fix for installing .cmake files in wrong location on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
    set(CMAKE_INSTALL_BINDIR bin)
    set(CMAKE_INSTALL_LIBDIR lib)
    set(CMAKE_INSTALL_INCLUDEDIR include)
-
+   set(CMAKE_DEBUG_POSTFIX d)
 endif()
 
 # required libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -720,13 +720,8 @@ configure_file(
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
    set(PKG_PREFIX "CopperSpice.framework/Resources")
-
-elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
-   set(PKG_PREFIX "cmake/CopperSpice")
-
 else()
    set(PKG_PREFIX "${CMAKE_INSTALL_LIBDIR}/cmake/CopperSpice")
-
 endif()
 
 install(

--- a/src/network/ssl/qsslcertificate.h
+++ b/src/network/ssl/qsslcertificate.h
@@ -124,7 +124,7 @@ class Q_NETWORK_EXPORT QSslCertificate
    static bool importPkcs12(QIODevice *device, QSslKey *key, QSslCertificate *certificate,
                   QList<QSslCertificate> *caCertificates = nullptr, const QByteArray &passPhrase = QByteArray());
 
-   static Q_NETWORK_EXPORT uint hash(const QSslCertificate &key, uint seed);
+   static uint hash(const QSslCertificate &key, uint seed);
 
    Qt::HANDLE handle() const;
 


### PR DESCRIPTION
This change installs CMake config files in CMAKE_PREFIX_PATH/lib, which seems to be where everyone else installs them.