### PR TITLE
MSVC 19.41.34123.0 flags an error when a static member function is de…

### DIFF
--- a/src/network/ssl/qsslcertificate.h
+++ b/src/network/ssl/qsslcertificate.h
@@ -124,7 +124,7 @@ class Q_NETWORK_EXPORT QSslCertificate
    static bool importPkcs12(QIODevice *device, QSslKey *key, QSslCertificate *certificate,
                   QList<QSslCertificate> *caCertificates = nullptr, const QByteArray &passPhrase = QByteArray());
 
-   static Q_NETWORK_EXPORT uint hash(const QSslCertificate &key, uint seed);
+   static uint hash(const QSslCertificate &key, uint seed);
 
    Qt::HANDLE handle() const;
 


### PR DESCRIPTION
…clared dllexport within a dllexport class.