### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/src/3rdparty/libtiff/libtiff/tif_ojpeg.c
+++ b/src/3rdparty/libtiff/libtiff/tif_ojpeg.c
@@ -244,6 +244,7 @@ typedef enum {
 
 typedef struct {
 	TIFF* tif;
+	int decoder_ok;
 	#ifndef LIBJPEG_ENCAP_EXTERNAL
 	JMP_BUF exit_jmpbuf;
 	#endif
@@ -722,6 +723,7 @@ OJPEGPreDecode(TIFF* tif, uint16 s)
 		}
 		sp->write_curstrile++;
 	}
+	sp->decoder_ok = 1;
 	return(1);
 }
 
@@ -784,8 +786,14 @@ OJPEGPreDecodeSkipScanlines(TIFF* tif)
 static int
 OJPEGDecode(TIFF* tif, uint8* buf, tmsize_t cc, uint16 s)
 {
+	static const char module[]="OJPEGDecode";
 	OJPEGState* sp=(OJPEGState*)tif->tif_data;
 	(void)s;
+	if(!sp->decoder_ok)
+	{
+		TIFFErrorExt(tif->tif_clientdata,module,"Cannot decode: decoder not correctly initialized");
+		return 0;
+	}
 	if (sp->libjpeg_jpeg_query_style==0)
 	{
 		if (OJPEGDecodeRaw(tif,buf,cc)==0)


### PR DESCRIPTION
Hi Development Team,

I identified another potential vulnerability in a clone function OJPEGDecode() in `/Users/ptnguyen/Disk/code_clone/repos/copperspice/src/3rdparty/libtiff/libtiff/tif_ojpeg.c`  sourced from [vadz/libtiff](https://github.com/vadz/libtiff). This issue, originally reported in [CVE-2016-10267](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2016-10267), was resolved in the repository via this commit https://github.com/vadz/libtiff/commit/43bc256d8ae44b92d2734a3c5bc73957a4d7c1ec.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!