### PR TITLE
This patch solves the compilation error in my openSUSE Leap 15.6

### DIFF
--- a/src/plugins/platforms/xcb/xcb.cmake
+++ b/src/plugins/platforms/xcb/xcb.cmake
@@ -15,6 +15,8 @@ if(BUILD_PLATFORMS_XCB_PLUGIN)
       ${CMAKE_CURRENT_SOURCE_DIR}/xcb/qxcb_main.cpp
    )
 
+   include_directories(${XKBCOMMON_INCLUDE_DIR})
+
    target_link_libraries(CsGuiXcb
       PRIVATE
       CsCore


### PR DESCRIPTION
installation.

It fails because "xkbcommon/xkbcommon.h" File is Not Found in

src/plugins/platforms/xcb/xcb_support/qxcb_keyboard.h

In my installation XKBCOMMON_INCLUDE_DIR is set to "/usr/include/libxkbcommon"

But XKBCOMMON_INCLUDE_DIR is not used.