### PR TITLE
fix url output with query

### DIFF
--- a/src/core/io/qurlrecode.cpp
+++ b/src/core/io/qurlrecode.cpp
@@ -308,6 +308,12 @@ void non_trivial ( QChar c, QString::const_iterator &iter, QString &retval, Enco
          retval.append('%');
          retval.append( toUpperHex(*++iter) );
          retval.append( toUpperHex(*++iter) );
+
+      } else {
+
+         retval.append('%');
+         retval.append( *++iter );
+         retval.append( *++iter );
       }
 
    } else if (c == '%' && action == DecodeCharacter) {


### PR DESCRIPTION
The already encoded case is not being handled correctly. As a result, the % character is removed and the hexadecimal pair is added to the resulting string during the following loop.

So here the existing encoded tripplet (%HH) is appended and the missed case is finally processed.