### PR TITLE
Fix connect with std::function for MSVC 18.6

### DIFF
--- a/src/annex/cs_signal/cs_internal.h
+++ b/src/annex/cs_signal/cs_internal.h
@@ -504,7 +504,7 @@ template<class T>
 void Bento<T>::invoke(SlotBase *, const TeaCupAbstract *dataPack) const
 {
    // T must be a class or it will be a compiler error
-   auto methodPtr = &T::operator();
+   auto methodPtr = static_cast<void (T::*)() const>(&T::operator());
 
    this->invoke_internal(dataPack, methodPtr);
 }


### PR DESCRIPTION
fixes #359

In Visual Studio 2026 18.6.x release, MS changed either the compiler o the STL implementation, which lead to the methodPtr type to be the base class of std::function which cannot automatically casts back to to T. This lead to Problems instantiating a correctly typed MethodReturn class needed later.