### PR TITLE
Fix compilation with Clang on Windows

### DIFF
--- a/src/core/tools/qsimd.cpp
+++ b/src/core/tools/qsimd.cpp
@@ -218,11 +218,13 @@ static void cpuidFeatures07_00(uint &ebx, uint &ecx)
 }
 
 #ifdef Q_OS_WIN
-// fallback overload in case this intrinsic does not exist: unsigned __int64 _xgetbv(unsigned int);
-inline quint64 _xgetbv(__int64)
-{
-   return 0;
-}
+#ifndef Q_CC_CLANG
+   // fallback overload in case this intrinsic does not exist: unsigned __int64 _xgetbv(unsigned int);
+   inline quint64 _xgetbv(__int64)
+   {
+      return 0;
+   }
+#endif
 #endif
 
 static void xgetbv(uint in, uint &eax, uint &edx)


### PR DESCRIPTION
This is a very trivial fix. Even though llvm-mingw is not supported officially, it costs nothing for you to incorporate it.

Update: This fix is also needed for the official Clang from LLVM.org.