### PR TITLE
Fix GitHub capitalization in README references

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ this project.
  * Email:    info@copperspice.com
 
 <!-- -->
- * Github:   https://github.com/copperspice
+ * GitHub:   https://github.com/copperspice
 
 <!-- -->
  * Forum:    https://forum.copperspice.com


### PR DESCRIPTION
## Summary
- Correct GitHub product name capitalization in the README references section (`Github` → `GitHub`) for consistency with branding.

## Test plan
- [x] Documentation-only change; no code or build configuration modified
- [x] Verified CMake can configure the project from a clean build directory