### PR TITLE
Document custom crash signal handler and fix MinGW build

### DIFF
--- a/src/core/io/qfilesystemengine_win.cpp
+++ b/src/core/io/qfilesystemengine_win.cpp
@@ -628,7 +628,7 @@ struct _FILE_ID_INFO {
 };
 
 using FILE_ID_INFO  = _FILE_ID_INFO;
-using PFILE_ID_INFO = *_FILE_ID_INFO;
+using PFILE_ID_INFO = _FILE_ID_INFO *;
 
 #endif
 

--- a/src/core/kernel/qcrashhandler.cpp
+++ b/src/core/kernel/qcrashhandler.cpp
@@ -281,6 +281,7 @@ static void print_backtrace(FILE *outb)
 }
 #endif
 
+// Custom signal handler entry point for crash diagnostics and user callbacks.
 void qt_signal_handler(int sig)
 {
    signal(sig, SIG_DFL);

--- a/src/core/kernel/qcrashhandler_p.h
+++ b/src/core/kernel/qcrashhandler_p.h
@@ -38,6 +38,7 @@ class Q_CORE_EXPORT QSegfaultHandler
  public:
    static void initialize(char **, int);
 
+   // Install a custom crash callback invoked from qt_signal_handler.
    static void installCrashHandler(FP_Void h) {
       callback = h;
    }


### PR DESCRIPTION
## Summary
- Add clarifying comments on `qt_signal_handler` and `installCrashHandler` in the crash handler
- Fix inverted MinGW pointer alias `PFILE_ID_INFO` (`*_FILE_ID_INFO` -> `_FILE_ID_INFO *`) that blocked Windows builds

## Build verification
- CMake + Ninja (MinGW g++) on Windows
- Fixed compile error in `qfilesystemengine_win.cpp`:631
- Successfully built and linked: CsCore, CsXml, CsNetwork, CsSql, tools (uic, rcc, lupdate, lrelease, lconvert)

## Test plan
- [x] `cmake --build build` configures and compiles CsCore after the MinGW fix
- [x] `libCsCore2.1.dll` links successfully
- [ ] Full WebKit/CsGui build (optional; very large on this host)